### PR TITLE
fix: Pin sagemaker dependancy version to before version 2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ deps =
     mock
     requests == 2.20.0
     urllib3 < 1.23, >= 1.21
-    sagemaker
+    sagemaker < 2
     sagemaker-containers
     torch
     torchvision


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
