### PR TITLE
Fixing issue #85 torch-model-archiver skips other other model artefacts 

### DIFF
--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -110,7 +110,15 @@ def start_torchserve(handler_service=DEFAULT_HANDLER_SERVICE):
 def _adapt_to_ts_format(handler_service):
     if not os.path.exists(DEFAULT_TS_MODEL_DIRECTORY):
         os.makedirs(DEFAULT_TS_MODEL_DIRECTORY)
-
+        
+    extra_files = []
+    extra_files.append(os.path.join(environment.model_dir, DEFAULT_TS_CODE_DIR, environment.Environment().module_name + ".py"))
+    extra_files+= [os.path.join(environment.model_dir, file) for file
+                                        in os.listdir(environment.model_dir)
+                                        if os.path.isfile(os.path.join(environment.model_dir, file))]
+    extra_files.remove(os.path.join(environment.model_dir, DEFAULT_TS_MODEL_SERIALIZED_FILE))
+    logger.info(extra_files)
+    
     model_archiver_cmd = [
         "torch-model-archiver",
         "--model-name",
@@ -122,7 +130,7 @@ def _adapt_to_ts_format(handler_service):
         "--export-path",
         DEFAULT_TS_MODEL_DIRECTORY,
         "--extra-files",
-        os.path.join(environment.model_dir, DEFAULT_TS_CODE_DIR, environment.Environment().module_name + ".py"),
+        ','.join(extra_files),
         "--version",
         "1",
     ]


### PR DESCRIPTION
*Issue # 85, if available:*

*Description of changes:*
`torch-model-archiver` skips model files in `model.tar.gz` except `model.pth`

This issue makes all pytorch inference containers >= 1.6 fails to launch models with multiple files in `model.tar.gz`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
