### PR TITLE
[WIP - DO NOT MERGE] Add UseContainerSupport flag for MMS to see all available CPUs 

### DIFF
--- a/artifacts/config.properties
+++ b/artifacts/config.properties
@@ -1,4 +1,4 @@
-vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
+vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError -XX:-UseContainerSupport
 model_store=/opt/ml/model
 load_models=ALL
 inference_address=http://0.0.0.0:8080

--- a/docker/1.2.0/py2/config.properties
+++ b/docker/1.2.0/py2/config.properties
@@ -1,4 +1,4 @@
-vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
+vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError -XX:-UseContainerSupport
 model_store=/opt/ml/model
 load_models=ALL
 inference_address=http://0.0.0.0:8080

--- a/docker/1.2.0/py3/config.properties
+++ b/docker/1.2.0/py3/config.properties
@@ -1,4 +1,4 @@
-vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
+vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError -XX:-UseContainerSupport
 model_store=/opt/ml/model
 load_models=ALL
 inference_address=http://0.0.0.0:8080

--- a/docker/build_artifacts/config.properties
+++ b/docker/build_artifacts/config.properties
@@ -1,4 +1,4 @@
-vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
+vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError -XX:-UseContainerSupport
 model_store=/opt/ml/model
 load_models=ALL
 inference_address=http://0.0.0.0:8080

--- a/src/sagemaker_pytorch_serving_container/etc/default-ts.properties
+++ b/src/sagemaker_pytorch_serving_container/etc/default-ts.properties
@@ -1,4 +1,5 @@
 # Based on https://github.com/pytorch/serve/blob/master/docs/configuration.md
+vmargs=-XX:-UseContainerSupport
 enable_envvars_config=true
 decode_input_request=false
 load_models=ALL


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
The PR add a VM_ARG `-XX:-UseContainerSupport` which MMS requires in order to see all the available CPUs when running in a container.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
