### PR TITLE
Support custom log4j.properties for torchserve

### DIFF
--- a/src/sagemaker_pytorch_serving_container/etc/log4j.properties
+++ b/src/sagemaker_pytorch_serving_container/etc/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger = INFO, console
+log4j.rootLogger = WARN, console
 
 log4j.appender.console = org.apache.log4j.ConsoleAppender
 log4j.appender.console.Target = System.out
@@ -40,11 +40,11 @@ log4j.appender.model_metrics.MaxBackupIndex = 5
 log4j.appender.model_metrics.layout = org.apache.log4j.PatternLayout
 log4j.appender.model_metrics.layout.ConversionPattern = %d{ISO8601} - %m%n
 
-log4j.logger.com.amazonaws.ml.ts = INFO, ts_log
-log4j.logger.ACCESS_LOG = INFO, access_log
-log4j.logger.TS_METRICS = INFO, ts_metrics
-log4j.logger.MODEL_METRICS = INFO, model_metrics
-log4j.logger.MODEL_LOG = INFO, model_log
+log4j.logger.com.amazonaws.ml.ts = WARN, ts_log
+log4j.logger.ACCESS_LOG = WARN, access_log
+log4j.logger.TS_METRICS = WARN, ts_metrics
+log4j.logger.MODEL_METRICS = WARN, model_metrics
+log4j.logger.MODEL_LOG = WARN, model_log
 
 log4j.logger.org.apache = OFF
 log4j.logger.io.netty = ERROR

--- a/src/sagemaker_pytorch_serving_container/etc/log4j.properties
+++ b/src/sagemaker_pytorch_serving_container/etc/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger = WARN, console
+log4j.rootLogger = INFO, console
 
 log4j.appender.console = org.apache.log4j.ConsoleAppender
 log4j.appender.console.Target = System.out
@@ -40,11 +40,11 @@ log4j.appender.model_metrics.MaxBackupIndex = 5
 log4j.appender.model_metrics.layout = org.apache.log4j.PatternLayout
 log4j.appender.model_metrics.layout.ConversionPattern = %d{ISO8601} - %m%n
 
-log4j.logger.com.amazonaws.ml.ts = WARN, ts_log
-log4j.logger.ACCESS_LOG = WARN, access_log
-log4j.logger.TS_METRICS = WARN, ts_metrics
-log4j.logger.MODEL_METRICS = WARN, model_metrics
-log4j.logger.MODEL_LOG = WARN, model_log
+log4j.logger.com.amazonaws.ml.ts = INFO, ts_log
+log4j.logger.ACCESS_LOG = INFO, access_log
+log4j.logger.TS_METRICS = INFO, ts_metrics
+log4j.logger.MODEL_METRICS = INFO, model_metrics
+log4j.logger.MODEL_LOG = INFO, model_log
 
 log4j.logger.org.apache = OFF
 log4j.logger.io.netty = ERROR

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -82,10 +82,13 @@ def start_torchserve(handler_service=DEFAULT_HANDLER_SERVICE):
     if os.path.exists(REQUIREMENTS_PATH):
         _install_requirements()
 
+    print(f"Checking {LOG4J_OVERRIDE_PATH}")
     if os.path.exists(LOG4J_OVERRIDE_PATH):
         log4j_path = LOG4J_OVERRIDE_PATH
+        print("Exists!")
     else:
         log4j_path = DEFAULT_TS_LOG_FILE
+        print("Doesn't exist :-(")
 
     ts_torchserve_cmd = [
         "torchserve",

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -50,6 +50,7 @@ MODEL_STORE = "/" if ENABLE_MULTI_MODEL else DEFAULT_TS_MODEL_DIRECTORY
 
 PYTHON_PATH_ENV = "PYTHONPATH"
 REQUIREMENTS_PATH = os.path.join(code_dir, "requirements.txt")
+LOG4J_OVERRIDE_PATH = os.path.join(code_dir, "log4j.properties")
 TS_NAMESPACE = "org.pytorch.serve.ModelServer"
 
 
@@ -81,6 +82,11 @@ def start_torchserve(handler_service=DEFAULT_HANDLER_SERVICE):
     if os.path.exists(REQUIREMENTS_PATH):
         _install_requirements()
 
+    if os.path.exists(LOG4J_OVERRIDE_PATH):
+        log4j_path = LOG4J_OVERRIDE_PATH
+    else:
+        log4j_path = DEFAULT_TS_LOG_FILE
+
     ts_torchserve_cmd = [
         "torchserve",
         "--start",
@@ -89,7 +95,7 @@ def start_torchserve(handler_service=DEFAULT_HANDLER_SERVICE):
         "--ts-config",
         TS_CONFIG_FILE,
         "--log-config",
-        DEFAULT_TS_LOG_FILE,
+        log4j_path,
         "--models",
         "model.mar"
     ]

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -82,13 +82,10 @@ def start_torchserve(handler_service=DEFAULT_HANDLER_SERVICE):
     if os.path.exists(REQUIREMENTS_PATH):
         _install_requirements()
 
-    print(f"Checking {LOG4J_OVERRIDE_PATH}")
     if os.path.exists(LOG4J_OVERRIDE_PATH):
         log4j_path = LOG4J_OVERRIDE_PATH
-        print("Exists!")
     else:
         log4j_path = DEFAULT_TS_LOG_FILE
-        print("Doesn't exist :-(")
 
     ts_torchserve_cmd = [
         "torchserve",


### PR DESCRIPTION
*Issue #, if available:*

By default, the logging level for `torchserve` is `INFO`, which can create a ton of logs. 

#83

*Description of changes:*


There is a hacky workaround where you can fork this repo, change the `log4j.properties`, and install that fork in `requirements.txt`, but the changes in this PR support a more elegant solution.

The code simply checks the code directory for `log4j.properties` (in exactly the same way it looks for `requirements.txt`). If it finds that file, it uses it for the logging configuration passed to `torchserve`. If it doesn't, it uses the default.
