### PR TITLE
Reference PyTorch instead of MXNet

### DIFF
--- a/src/sagemaker_pytorch_serving_container/handler_service.py
+++ b/src/sagemaker_pytorch_serving_container/handler_service.py
@@ -26,13 +26,13 @@ class HandlerService(DefaultHandlerService):
 
     """Handler service that is executed by the model server.
 
-    Determines specific default inference handlers to use based on the type MXNet model being used.
+    Determines specific default inference handlers to use based on the type of PyTorch model being used.
 
     This class extends ``DefaultHandlerService``, which define the following:
         - The ``handle`` method is invoked for all incoming inference requests to the model server.
         - The ``initialize`` method is invoked at model server start up.
 
-    Based on: https://github.com/awslabs/mxnet-model-server/blob/master/docs/custom_service.md
+    Based on: https://github.com/awslabs/multi-model-server/blob/master/docs/custom_service.md
 
     """
     def __init__(self):


### PR DESCRIPTION
Documentation was erroneously referring to MXNet despite this handler service being written for PyTorch

*Issue #, if available:*

*Description of changes:*
Documentation only
* Changed `MxNet` to `PyTorch`
* Update `custom_service` documentation url to point towards correct location

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
