### PR TITLE
Update PyTorch Inference toolkit to log telemetry metrics

### DIFF
--- a/src/sagemaker_pytorch_serving_container/etc/log4j2.xml
+++ b/src/sagemaker_pytorch_serving_container/etc/log4j2.xml
@@ -59,6 +59,17 @@
             </Policies>
             <DefaultRolloverStrategy max="5"/>
         </RollingFile>
+        <ScriptAppenderSelector name="telemetry_metrics">
+				<Script language="JavaScript"><![CDATA[
+				java.lang.System.getenv("SM_TELEMETRY_LOG") == null ? "null_appender" : "remote_appender";]]>
+		</Script>
+		<AppenderSet>
+				<Null name="null_appender"/>
+		<File name="remote_appender" fileName="${env:SM_TELEMETRY_LOG}">
+				<PatternLayout pattern="%m%n"/>
+		</File>
+		</AppenderSet>
+		</ScriptAppenderSelector>
     </Appenders>
     <Loggers>
         <Logger name="ACCESS_LOG" level="info">
@@ -78,10 +89,12 @@
         <Logger name="TS_METRICS" level="info">
             <AppenderRef ref="ts_metrics"/>
         </Logger>
+        <Logger name="TELEMETRY_METRICS" level="all">
+            <AppenderRef ref="telemetry_metrics"/>
+		</Logger>
         <Root level="info">
             <AppenderRef ref="STDOUT"/>
             <AppenderRef ref="ts_log"/>
         </Root>
     </Loggers>
 </Configuration>
-

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -99,9 +99,8 @@ def start_torchserve(handler_service=DEFAULT_HANDLER_SERVICE):
 
     print(ts_torchserve_cmd)
 
-    docker_env = os.environ.copy()
     logger.info(ts_torchserve_cmd)
-    subprocess.Popen(ts_torchserve_cmd, env=docker_env)
+    subprocess.Popen(ts_torchserve_cmd)
 
     ts_process = _retrieve_ts_server_process()
 

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -99,8 +99,9 @@ def start_torchserve(handler_service=DEFAULT_HANDLER_SERVICE):
 
     print(ts_torchserve_cmd)
 
+    docker_env = os.environ.copy()
     logger.info(ts_torchserve_cmd)
-    subprocess.Popen(ts_torchserve_cmd)
+    subprocess.Popen(ts_torchserve_cmd, env=docker_env)
 
     ts_process = _retrieve_ts_server_process()
 


### PR DESCRIPTION
Creating PR to update Pytorch Inference toolkit to log telemetry metrics in case of failure.

TorchServe PR: https://github.com/pytorch/serve/pull/1974

Telemetry Design Doc: https://quip-amazon.com/8hW4AJQQu4Na/Inference-Telemetry-Failure-rate-low-level-design

Please refer to this document for more details about the PR: https://quip-amazon.com/VMoqANQATkNH/Code-Changes-in-TorchServe-and-PyTorch-Inference-Toolkit-to-Log-Telemetry-Metrics

Example code block for logging telemetry metrics:
```
loggerTelemetryMetrics.info("ModelServerError.Count:1|#TorchServe:{},{}:-1", ConfigManager.getInstance().getVersion(), "error");
```
Sample output:
```
ModelServerError.Count:1|#TorchServe:0.6.1,error:-1
ModelServerError.Count:1|#TorchServe:0.6.1,error:-1
ModelServerError.Count:1|#TorchServe:0.6.1,error:-1
ModelServerError.Count:1|#TorchServe:0.6.1,error:-1
```

[filtered_telemetry.log](https://github.com/aws/sagemaker-pytorch-inference-toolkit/files/10079103/filtered_telemetry.log)
[snippet_ts_log.log](https://github.com/aws/sagemaker-pytorch-inference-toolkit/files/10079106/snippet_ts_log.log)
![telemetry_cloudwatch_log](https://user-images.githubusercontent.com/110572198/203643571-77784be8-eda6-4182-b77f-997910eecd60.png)
