### PR TITLE
configure min torchserve version dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
 
     # We don't declare our dependency on torch here because we build with
     # different packages for different variants
-    install_requires=['numpy', 'retrying', 'sagemaker-inference>=1.3.1'],
+    install_requires=['numpy', 'retrying', 'sagemaker-inference>=1.3.1', 'torchserve>=0.5.3'],
     extras_require={
         'test': ['boto3>=1.10.44', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
                  'mock==2.0.0', 'pytest==4.4.0', 'pytest-cov==2.7.1', 'pytest-xdist==1.28.0', 'PyYAML==3.10',


### PR DESCRIPTION
Configure minimum version of `torchserve` required for `sagemaker-pytorch-inference-toolkit`. Torchserve upgraded log4j version in 0.5.3 [release](https://github.com/pytorch/serve/releases/tag/v0.5.3).
