### PR TITLE
Add support for SAGEMAKER_MAX_PAYLOAD_IN_MB

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
 
     # We don't declare our dependency on torch here because we build with
     # different packages for different variants
-    install_requires=['numpy', 'retrying', 'sagemaker-inference>=1.3.1'],
+    install_requires=['numpy', 'retrying', 'sagemaker-inference>=1.9.2'],
     extras_require={
         'test': ['boto3>=1.10.44', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
                  'mock==2.0.0', 'pytest==4.4.0', 'pytest-cov==2.7.1', 'pytest-xdist==1.28.0', 'PyYAML==3.10',

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -134,6 +134,7 @@ def _generate_ts_config_properties(handler_service):
         "inference_address": "http://0.0.0.0:{}".format(env.inference_http_port),
         "management_address": "http://0.0.0.0:{}".format(env.management_http_port),
         "default_service_handler": handler_service + ":handle",
+        "max_request_size": env.max_request_size,
     }
 
     ts_env = ts_environment.TorchServeEnvironment()

--- a/test/unit/test_model_server.py
+++ b/test/unit/test_model_server.py
@@ -144,21 +144,25 @@ def test_generate_ts_config_properties(env, read_file):
     model_server_timeout = "torchserve_timeout"
     model_server_workers = "torchserve_workers"
     http_port = "http_port"
+    max_request_size = 10485760
 
     env.return_value.model_server_timeout = model_server_timeout
     env.return_value.model_sever_workerse = model_server_workers
     env.return_value.inference_http_port = http_port
+    env.return_value.max_request_size = max_request_size
 
     ts_config_properties = torchserve._generate_ts_config_properties(torchserve.DEFAULT_HANDLER_SERVICE)
 
     inference_address = "inference_address=http://0.0.0.0:{}\n".format(http_port)
     server_timeout = "default_response_timeout={}\n".format(model_server_timeout)
+    max_request_size_config = "max_request_size={}\n".format(max_request_size)
 
     read_file.assert_called_once_with(torchserve.DEFAULT_TS_CONFIG_FILE)
 
     assert ts_config_properties.startswith(DEFAULT_CONFIGURATION)
     assert inference_address in ts_config_properties
     assert server_timeout in ts_config_properties
+    assert max_request_size_config in ts_config_properties
 
 
 @patch("sagemaker_inference.utils.read_file", return_value=DEFAULT_CONFIGURATION)


### PR DESCRIPTION
*Description of changes:*
Sagemaker batch transform [sets](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-batch-code.html) `SAGEMAKER_MAX_PAYLOAD_IN_MB` env var which is currently not handled and passed to the model server. Adding support for the same based on the following PR in base toolkit: https://github.com/aws/sagemaker-inference-toolkit/pull/121

*Testing:*
- Unit test added in PR
- Tested locally using `763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference:1.13.1-cpu-py39-ubuntu20.04-sagemaker`
```
$ export SAGEMAKER_MAX_PAYLOAD_IN_MB=10
$ python /usr/local/bin/dockerd-entrypoint.py serve
$ vim logs/ts_log.log
2023-04-08T00:53:18,889 [INFO ] main org.pytorch.serve.servingsdk.impl.PluginsManager - Initializing plugins manager...
2023-04-08T00:53:18,889 [INFO ] main org.pytorch.serve.servingsdk.impl.PluginsManager - Initializing plugins manager...
2023-04-08T00:53:18,979 [INFO ] main org.pytorch.serve.ModelServer -
Torchserve version: 0.7.0
TS Home: /opt/conda/lib/python3.9/site-packages
Current directory: /
Temp directory: /home/model-server/tmp
Metrics config path: /opt/conda/lib/python3.9/site-packages/ts/configs/metrics.yaml
Number of GPUs: 0
Number of CPUs: 16
Max heap size: 15824 M
Python executable: /opt/conda/bin/python3.9
Config file: /etc/sagemaker-ts.properties
Inference address: http://0.0.0.0:8080
Management address: http://0.0.0.0:8080
Metrics address: http://127.0.0.1:8082
Model Store: /.sagemaker/ts/models
Initial Models: model=/opt/ml/model
Log dir: /logs
Metrics dir: /logs
Netty threads: 0
Netty client threads: 0
Default workers per model: 16
Blacklist Regex: N/A
Maximum Response Size: 6553500
Maximum Request Size: 10485760
Limit Maximum Image Pixels: true
```
Note that Maximum request size is set to `10 * 1024 * 1024` bytes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
