### PR TITLE
Enable vmargs argument for torchserve

### DIFF
--- a/src/sagemaker_pytorch_serving_container/etc/default-ts.properties
+++ b/src/sagemaker_pytorch_serving_container/etc/default-ts.properties
@@ -1,5 +1,4 @@
 # Based on https://github.com/pytorch/serve/blob/master/docs/configuration.md
-vmargs=-XX:-UseContainerSupport
 enable_envvars_config=true
 decode_input_request=false
 load_models=ALL

--- a/src/sagemaker_pytorch_serving_container/etc/mme-ts.properties
+++ b/src/sagemaker_pytorch_serving_container/etc/mme-ts.properties
@@ -1,4 +1,3 @@
-vmargs=-XX:-UseContainerSupport
 enable_envvars_config=true
 model_store=/
 default_service_handler=$$SAGEMAKER_HANDLER$$

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -134,6 +134,7 @@ def _generate_ts_config_properties(handler_service):
         "inference_address": "http://0.0.0.0:{}".format(env.inference_http_port),
         "management_address": "http://0.0.0.0:{}".format(env.management_http_port),
         "default_service_handler": handler_service + ":handle",
+        "vmargs": env.vmargs,
     }
 
     ts_env = ts_environment.TorchServeEnvironment()


### PR DESCRIPTION
*Issue #, if available:*
The torchserve vmargs argument is hard-coded and by default uses a small fraction of the total available memory. This causes issues when loading models into memory.

*Description of changes:*
The torchserve configuration process now respects the pre-existing environment variable "SAGEMAKER_MODEL_SERVER_VMARGS". When this environment variable is missing, the default value (taken from sagemaker_inference.environment) matches the previously hard-coded value.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
