### PR TITLE
Fix integration tests and update Python versions

### DIFF
--- a/buildspec-release.yml
+++ b/buildspec-release.yml
@@ -12,7 +12,7 @@ phases:
       # run unit tests
       - AWS_ACCESS_KEY_ID= AWS_SECRET_ACCESS_KEY= AWS_SESSION_TOKEN=
         AWS_CONTAINER_CREDENTIALS_RELATIVE_URI= AWS_DEFAULT_REGION=
-        tox -e py36,py37 -- test/unit
+        tox -e py38,py39,py310 -- test/unit
 
       # run local integ tests
       #- $(aws ecr get-login --no-include-email --region us-west-2)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -79,7 +79,7 @@ phases:
         for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS; 
           do
             DLC_CPU_TAG="$FRAMEWORK_VERSION-dlc-cpu-$BUILD_ID";
-            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG";
+            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --tag $DLC_CPU_TAG";
             execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg";
             docker system prune --all --force;
           done
@@ -89,7 +89,7 @@ phases:
         for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS;
           do
             DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID";
-            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG";
+            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG";
             execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg";
             docker system prune --all --force;
           done

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,11 +2,11 @@ version: 0.2
 
 env:
   variables:
-    FRAMEWORK_VERSION: '2.0.1'
-    EIA_FRAMEWORK_VERSION: '1.3.1'
+    FRAMEWORK_VERSIONS: '2.0.0 2.0.1'
+    # EIA_FRAMEWORK_VERSION: '1.3.1'
     CPU_INSTANCE_TYPE: 'ml.c4.xlarge'
-    GPU_INSTANCE_TYPE: 'ml.g4dn.xlarge'
-    EIA_ACCELERATOR_TYPE: 'ml.eia2.medium'
+    GPU_INSTANCE_TYPE: 'ml.g4dn.12xlarge'
+    # EIA_ACCELERATOR_TYPE: 'ml.eia2.medium'
     ECR_REPO: 'sagemaker-test'
     GITHUB_REPO: 'sagemaker-pytorch-serving-container'
     DLC_ACCOUNT: '763104351884'
@@ -35,54 +35,79 @@ phases:
       # run unit tests
       - tox -e py38,py39,py310 test/unit
 
-      # define tags
-      - DLC_CPU_TAG="$FRAMEWORK_VERSION-dlc-cpu-$BUILD_ID"
-      - DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID"
-      - DLC_EIA_TAG="$EIA_FRAMEWORK_VERSION-dlc-eia-$BUILD_ID"
+      # define EIA tag
+      # - DLC_EIA_TAG="$EIA_FRAMEWORK_VERSION-dlc-eia-$BUILD_ID"
 
       # run local CPU integration tests (build and push the image to ECR repo)
-      - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/local -vv -rA -s --build-image --push-image --dockerfile-type dlc.cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --tag $DLC_CPU_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
+      - |
+        for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS; 
+          do
+            DLC_CPU_TAG="$FRAMEWORK_VERSION-dlc-cpu-$BUILD_ID";
+            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/local -vv -rA -s --build-image --push-image --dockerfile-type dlc.cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --tag $DLC_CPU_TAG";
+            execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg";
+            docker system prune --all --force;
+          done
 
       # launch remote GPU instance with Deep Learning AMI GPU PyTorch 1.9 (Ubuntu 20.04)
       - prefix='ml.'
       - instance_type=${GPU_INSTANCE_TYPE#"$prefix"}
-      - create-key-pair
-      - launch-ec2-instance --instance-type $instance_type --ami-name ami-03e3ef8c92fdb39ad
-
+      
       # build DLC GPU image because the base DLC image is too big and takes too long to build as part of the test
       - python3 setup.py sdist
-      - build_dir="test/container/$FRAMEWORK_VERSION"
       - $(aws ecr get-login --registry-ids $DLC_ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
-      - docker build -f "$build_dir/Dockerfile.dlc.gpu" -t $PREPROD_IMAGE:$DLC_GPU_TAG --build-arg region=$AWS_DEFAULT_REGION .
-      # push DLC GPU image to ECR
-      - $(aws ecr get-login --registry-ids $ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
-      - docker push $PREPROD_IMAGE:$DLC_GPU_TAG
-
-      # run GPU local integration tests
-      - printf "$SETUP_CMDS" > $SETUP_FILE
-      - dlc_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/local -vv -rA -s --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG"
-      - test_cmd="remote-test --github-repo $GITHUB_REPO --test-cmd \"$dlc_cmd\" --setup-file $SETUP_FILE --pr-number \"$PR_NUM\" --python-version \"3.8\""
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
+      - |
+        for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS;
+          do
+            create-key-pair;
+            launch-ec2-instance --instance-type $instance_type --ami-name ami-03e3ef8c92fdb39ad;
+            DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID";
+            build_dir="test/container/$FRAMEWORK_VERSION";
+            docker build -f "$build_dir/Dockerfile.dlc.gpu" -t $PREPROD_IMAGE:$DLC_GPU_TAG --build-arg region=$AWS_DEFAULT_REGION .;
+            $(aws ecr get-login --registry-ids $ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION);
+            docker push $PREPROD_IMAGE:$DLC_GPU_TAG;
+            printf "$SETUP_CMDS" > $SETUP_FILE;
+            dlc_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/local -vv -rA -s --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG";
+            test_cmd="remote-test --github-repo $GITHUB_REPO --test-cmd \"$dlc_cmd\" --setup-file $SETUP_FILE --pr-number \"$PR_NUM\" --python-version \"3.8\"";
+            execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg";
+            docker system prune --all --force;
+            cleanup-gpu-instances;
+            cleanup-key-pairs;
+          done
 
       # run CPU sagemaker integration tests
-      - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
+      - |
+        for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS; 
+          do
+            DLC_CPU_TAG="$FRAMEWORK_VERSION-dlc-cpu-$BUILD_ID";
+            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG";
+            execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg";
+            docker system prune --all --force;
+          done
 
       # run GPU sagemaker integration tests
-      - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
+      - |
+        for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS;
+          do
+            DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID";
+            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG";
+            execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg";
+            docker system prune --all --force;
+          done
 
       # run EIA sagemaker integration tests
-      - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --build-image --push-image --dockerfile-type dlc.eia --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $EIA_FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --accelerator-type $EIA_ACCELERATOR_TYPE --tag $DLC_EIA_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
+      # - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --build-image --push-image --dockerfile-type dlc.eia --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $EIA_FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --accelerator-type $EIA_ACCELERATOR_TYPE --tag $DLC_EIA_TAG"
+      # - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
 
     finally:
-      # shut down remote GPU instance
-      - cleanup-gpu-instances
-      - cleanup-key-pairs
 
       # remove ECR image
-      - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_CPU_TAG
-      - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_GPU_TAG
-      - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_EIA_TAG
+      - |
+        for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS; 
+          do
+            DLC_CPU_TAG="$FRAMEWORK_VERSION-dlc-cpu-$BUILD_ID";
+            DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID";
+            aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_CPU_TAG;
+            aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_GPU_TAG;
+          done
+      
+      # - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_EIA_TAG

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -79,7 +79,7 @@ phases:
         for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS; 
           do
             DLC_CPU_TAG="$FRAMEWORK_VERSION-dlc-cpu-$BUILD_ID";
-            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --tag $DLC_CPU_TAG";
+            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG";
             execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg";
             docker system prune --all --force;
           done
@@ -89,7 +89,7 @@ phases:
         for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS;
           do
             DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID";
-            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG";
+            test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG";
             execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg";
             docker system prune --all --force;
           done

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,16 +2,16 @@ version: 0.2
 
 env:
   variables:
-    FRAMEWORK_VERSION: '1.10.2'
+    FRAMEWORK_VERSION: '2.0.1'
     EIA_FRAMEWORK_VERSION: '1.3.1'
     CPU_INSTANCE_TYPE: 'ml.c4.xlarge'
-    GPU_INSTANCE_TYPE: 'ml.p3.8xlarge'
+    GPU_INSTANCE_TYPE: 'ml.g4dn.xlarge'
     EIA_ACCELERATOR_TYPE: 'ml.eia2.medium'
     ECR_REPO: 'sagemaker-test'
     GITHUB_REPO: 'sagemaker-pytorch-serving-container'
     DLC_ACCOUNT: '763104351884'
     SETUP_FILE: 'setup_cmds.sh'
-    SETUP_CMDS: '#!/bin/bash\npython3.6 -m pip install --upgrade pip\npython3.6 -m pip install -U -e .\npython3.6 -m pip install -U -e .[test]'
+    SETUP_CMDS: '#!/bin/bash\npython3.8 -m pip install --upgrade pip\npython3.8 -m pip install -U -e .\npython3.8 -m pip install -U -e .[test]'
 
 
 phases:
@@ -33,25 +33,22 @@ phases:
       - tox -e flake8,twine
 
       # run unit tests
-      - tox -e py36,py37 test/unit
+      - tox -e py38,py39,py310 test/unit
 
       # define tags
-      - GENERIC_TAG="$FRAMEWORK_VERSION-pytorch-$BUILD_ID"
       - DLC_CPU_TAG="$FRAMEWORK_VERSION-dlc-cpu-$BUILD_ID"
       - DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID"
       - DLC_EIA_TAG="$EIA_FRAMEWORK_VERSION-dlc-eia-$BUILD_ID"
 
       # run local CPU integration tests (build and push the image to ECR repo)
-      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local -vv -rA -s --build-image --push-image --dockerfile-type pytorch --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --tag $GENERIC_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
-      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local -vv -rA -s --build-image --push-image --dockerfile-type dlc.cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --tag $DLC_CPU_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
+      - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/local -vv -rA -s --build-image --push-image --dockerfile-type dlc.cpu --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --tag $DLC_CPU_TAG"
+      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
 
-      # launch remote GPU instance
+      # launch remote GPU instance with Deep Learning AMI GPU PyTorch 1.9 (Ubuntu 20.04)
       - prefix='ml.'
       - instance_type=${GPU_INSTANCE_TYPE#"$prefix"}
       - create-key-pair
-      - launch-ec2-instance --instance-type $instance_type --ami-name dlami-ubuntu-latest
+      - launch-ec2-instance --instance-type $instance_type --ami-name ami-03e3ef8c92fdb39ad
 
       # build DLC GPU image because the base DLC image is too big and takes too long to build as part of the test
       - python3 setup.py sdist
@@ -64,29 +61,21 @@ phases:
 
       # run GPU local integration tests
       - printf "$SETUP_CMDS" > $SETUP_FILE
-      # no reason to rebuild the image again since it was already built and pushed to ECR during CPU tests
-      - generic_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local -vv -rA -s --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $GENERIC_TAG"
-      - test_cmd="remote-test --github-repo $GITHUB_REPO --test-cmd \"$generic_cmd\" --setup-file $SETUP_FILE --pr-number \"$PR_NUM\""
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
-      - dlc_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/local -vv -rA -s --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG"
-      - test_cmd="remote-test --github-repo $GITHUB_REPO --test-cmd \"$dlc_cmd\" --setup-file $SETUP_FILE --pr-number \"$PR_NUM\" --skip-setup"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
+      - dlc_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/local -vv -rA -s --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --tag $DLC_GPU_TAG"
+      - test_cmd="remote-test --github-repo $GITHUB_REPO --test-cmd \"$dlc_cmd\" --setup-file $SETUP_FILE --pr-number \"$PR_NUM\" --python-version \"3.8\""
+      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
 
       # run CPU sagemaker integration tests
-      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $GENERIC_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
-      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
+      - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --tag $DLC_CPU_TAG"
+      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
 
       # run GPU sagemaker integration tests
-      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $GENERIC_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
-      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
+      - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $FRAMEWORK_VERSION --processor gpu --instance-type $GPU_INSTANCE_TYPE --tag $DLC_GPU_TAG"
+      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
 
       # run EIA sagemaker integration tests
-      - test_cmd="IGNORE_COVERAGE=- tox -e py36 -- test/integration/sagemaker --build-image --push-image --dockerfile-type dlc.eia --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $EIA_FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --accelerator-type $EIA_ACCELERATOR_TYPE --tag $DLC_EIA_TAG"
-      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg" "buildspec-toolkit.yml" "artifacts/*"
+      - test_cmd="IGNORE_COVERAGE=- tox -e py38 -- test/integration/sagemaker --build-image --push-image --dockerfile-type dlc.eia --region $AWS_DEFAULT_REGION --docker-base-name $ECR_REPO --aws-id $ACCOUNT --framework-version $EIA_FRAMEWORK_VERSION --processor cpu --instance-type $CPU_INSTANCE_TYPE --accelerator-type $EIA_ACCELERATOR_TYPE --tag $DLC_EIA_TAG"
+      - execute-command-if-has-matching-changes "$test_cmd" "test/" "src/*.py" "setup.py" "setup.cfg"
 
     finally:
       # shut down remote GPU instance
@@ -94,7 +83,6 @@ phases:
       - cleanup-key-pairs
 
       # remove ECR image
-      - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$GENERIC_TAG
       - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_CPU_TAG
       - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_GPU_TAG
       - aws ecr batch-delete-image --repository-name $ECR_REPO --region $AWS_DEFAULT_REGION --image-ids imageTag=$DLC_EIA_TAG

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,12 @@ setup(
 
     # We don't declare our dependency on torch here because we build with
     # different packages for different variants
-    install_requires=['numpy', 'retrying', 'sagemaker-inference>=1.3.1'],
+    install_requires=['numpy==1.24.4', 'retrying==1.3.4', 'sagemaker-inference==1.10.0'],
     extras_require={
-        'test': ['boto3', 'coverage', 'docker-compose', 'flake8', 'Flask',
-                 'mock', 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML',
-                 'sagemaker==2.125.0', 'six', 'requests',
-                 'requests_mock', 'torch', 'torchvision', 'tox']
+        'test': ['boto3==1.28.60', 'coverage==7.3.2', 'docker-compose==1.29.2', 'flake8==6.1.0', 'Flask==3.0.0',
+                 'mock==5.1.0', 'pytest==7.4.2', 'pytest-cov==4.1.0', 'pytest-xdist==3.3.1', 'PyYAML==5.4.1',
+                 'sagemaker==2.125.0', 'six==1.16.0', 'requests==2.31.0',
+                 'requests_mock==1.11.0', 'torch==2.1.0', 'torchvision==0.16.0', 'tox==4.11.3']
     },
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -45,19 +45,19 @@ setup(
         "Natural Language :: English",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
     ],
 
     # We don't declare our dependency on torch here because we build with
     # different packages for different variants
     install_requires=['numpy', 'retrying', 'sagemaker-inference>=1.3.1'],
     extras_require={
-        'test': ['boto3>=1.10.44', 'coverage==4.5.3', 'docker-compose==1.23.2', 'flake8==3.7.7', 'Flask==1.1.1',
-                 'mock==2.0.0', 'pytest==4.4.0', 'pytest-cov==2.7.1', 'pytest-xdist==1.28.0', 'PyYAML==3.10',
-                 'sagemaker==1.56.3', 'sagemaker-containers>=2.5.4', 'six==1.12.0', 'requests==2.20.0',
-                 'requests_mock==1.6.0', 'torch==1.6.0', 'torchvision==0.7.0', 'tox==3.7.0']
+        'test': ['boto3', 'coverage', 'docker-compose', 'flake8', 'Flask',
+                 'mock', 'pytest', 'pytest-cov', 'pytest-xdist', 'PyYAML',
+                 'sagemaker==2.125.0', 'six', 'requests',
+                 'requests_mock', 'torch', 'torchvision', 'tox']
     },
 
     entry_points={

--- a/src/sagemaker_pytorch_serving_container/default_pytorch_inference_handler.py
+++ b/src/sagemaker_pytorch_serving_container/default_pytorch_inference_handler.py
@@ -135,7 +135,7 @@ class DefaultPytorchInferenceHandler(default_inference_handler.DefaultInferenceH
 
         Returns: output data serialized
         """
-        if type(prediction) == torch.Tensor:
+        if type(prediction) is torch.Tensor:
             prediction = prediction.detach().cpu().numpy().tolist()
 
         for content_type in utils.parse_accept(accept):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -45,15 +45,16 @@ def pytest_addoption(parser):
     parser.addoption('--build-image', '-B', action='store_true')
     parser.addoption('--push-image', '-P', action='store_true')
     parser.addoption('--dockerfile-type', '-T',
-                     choices=['dlc.cpu', 'dlc.gpu', 'dlc.eia', 'pytorch'],
-                     default='pytorch')
+                     # choices=['dlc.cpu', 'dlc.gpu', 'dlc.eia', 'pytorch'],
+                     choices=['dlc.cpu', 'dlc.gpu'],
+                     default='dlc.cpu')
     parser.addoption('--dockerfile', '-D', default=None)
     parser.addoption('--aws-id', default=None)
     parser.addoption('--instance-type')
     parser.addoption('--accelerator-type')
     parser.addoption('--docker-base-name', default='sagemaker-pytorch-inference')
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default="1.6.0")
+    parser.addoption('--framework-version', default="2.0.0")
     parser.addoption('--py-version', choices=['2', '3'], default='3')
     # Processor is still "cpu" for EIA tests
     parser.addoption('--processor', choices=['gpu', 'cpu'], default='cpu')

--- a/test/container/2.0.0/Dockerfile.dlc.cpu
+++ b/test/container/2.0.0/Dockerfile.dlc.cpu
@@ -1,8 +1,8 @@
 ARG region
 FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.0-cpu-py310-ubuntu20.04-sagemaker
 
-RUN pip uninstall -y sagemaker_pytorch_inference
-
 COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
-RUN pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
+
+RUN pip uninstall -y sagemaker_pytorch_inference && \
+    pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
     rm /sagemaker_pytorch_inference.tar.gz

--- a/test/container/2.0.0/Dockerfile.dlc.cpu
+++ b/test/container/2.0.0/Dockerfile.dlc.cpu
@@ -1,0 +1,8 @@
+ARG region
+FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.0-cpu-py310-ubuntu20.04-sagemaker
+
+RUN pip uninstall -y sagemaker_pytorch_inference
+
+COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
+RUN pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
+    rm /sagemaker_pytorch_inference.tar.gz

--- a/test/container/2.0.0/Dockerfile.dlc.gpu
+++ b/test/container/2.0.0/Dockerfile.dlc.gpu
@@ -1,0 +1,8 @@
+ARG region
+FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.0-gpu-py310-cu118-ubuntu20.04-sagemaker
+
+RUN pip uninstall -y sagemaker_pytorch_inference
+
+COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
+RUN pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
+    rm /sagemaker_pytorch_inference.tar.gz

--- a/test/container/2.0.0/Dockerfile.dlc.gpu
+++ b/test/container/2.0.0/Dockerfile.dlc.gpu
@@ -1,8 +1,8 @@
 ARG region
 FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.0-gpu-py310-cu118-ubuntu20.04-sagemaker
 
-RUN pip uninstall -y sagemaker_pytorch_inference
-
 COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
-RUN pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
+
+RUN pip uninstall -y sagemaker_pytorch_inference && \
+    pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
     rm /sagemaker_pytorch_inference.tar.gz

--- a/test/container/2.0.1/Dockerfile.dlc.cpu
+++ b/test/container/2.0.1/Dockerfile.dlc.cpu
@@ -1,0 +1,8 @@
+ARG region
+FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.1-cpu-py310-ubuntu20.04-sagemaker
+
+RUN pip uninstall -y sagemaker_pytorch_inference
+
+COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
+RUN pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
+    rm /sagemaker_pytorch_inference.tar.gz

--- a/test/container/2.0.1/Dockerfile.dlc.cpu
+++ b/test/container/2.0.1/Dockerfile.dlc.cpu
@@ -1,8 +1,8 @@
 ARG region
 FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.1-cpu-py310-ubuntu20.04-sagemaker
 
-RUN pip uninstall -y sagemaker_pytorch_inference
-
 COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
-RUN pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
+
+RUN pip uninstall -y sagemaker_pytorch_inference && \
+    pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
     rm /sagemaker_pytorch_inference.tar.gz

--- a/test/container/2.0.1/Dockerfile.dlc.gpu
+++ b/test/container/2.0.1/Dockerfile.dlc.gpu
@@ -1,0 +1,8 @@
+ARG region
+FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.1-gpu-py310-cu118-ubuntu20.04-sagemaker
+
+RUN pip uninstall -y sagemaker_pytorch_inference
+
+COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
+RUN pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
+    rm /sagemaker_pytorch_inference.tar.gz

--- a/test/container/2.0.1/Dockerfile.dlc.gpu
+++ b/test/container/2.0.1/Dockerfile.dlc.gpu
@@ -1,8 +1,8 @@
 ARG region
 FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.1-gpu-py310-cu118-ubuntu20.04-sagemaker
 
-RUN pip uninstall -y sagemaker_pytorch_inference
-
 COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
-RUN pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
+
+RUN pip uninstall -y sagemaker_pytorch_inference && \
+    pip install --upgrade --no-cache-dir /sagemaker_pytorch_inference.tar.gz && \
     rm /sagemaker_pytorch_inference.tar.gz

--- a/test/integration/local/test_serving.py
+++ b/test/integration/local/test_serving.py
@@ -20,9 +20,9 @@ import torch
 import torch.utils.data
 import torch.utils.data.distributed
 from sagemaker.pytorch import PyTorchModel
-from sagemaker.predictor import BytesDeserializer, csv_deserializer, csv_serializer, \
-    json_deserializer, json_serializer, npy_serializer, numpy_deserializer
-from sagemaker_containers.beta.framework import content_types
+from sagemaker import deserializers
+from sagemaker import serializers
+from sagemaker_inference import content_types
 from torchvision import datasets, transforms
 
 from integration import training_dir, mnist_1d_script, model_cpu_tar, mnist_cpu_script, \
@@ -31,15 +31,15 @@ from integration import training_dir, mnist_1d_script, model_cpu_tar, mnist_cpu_
 from utils import local_mode_utils
 
 CONTENT_TYPE_TO_SERIALIZER_MAP = {
-    content_types.CSV: csv_serializer,
-    content_types.JSON: json_serializer,
-    content_types.NPY: npy_serializer,
+    content_types.CSV: serializers.CSVSerializer(),
+    content_types.JSON: serializers.JSONSerializer(),
+    content_types.NPY: serializers.NumpySerializer()
 }
 
 ACCEPT_TYPE_TO_DESERIALIZER_MAP = {
-    content_types.CSV: csv_deserializer,
-    content_types.JSON: json_deserializer,
-    content_types.NPY: numpy_deserializer,
+    content_types.CSV: deserializers.CSVDeserializer(),
+    content_types.JSON: deserializers.JSONDeserializer(),
+    content_types.NPY: deserializers.NumpyDeserializer()
 }
 
 
@@ -66,8 +66,9 @@ def test_serve_csv(test_loader, use_gpu, image_uri, sagemaker_local_session, ins
             _assert_prediction_csv(predictor, test_loader, accept)
 
 
-@pytest.mark.skip_cpu
 def test_serve_cpu_model_on_gpu(test_loader, image_uri, sagemaker_local_session, instance_type):
+    if 'cpu' in image_uri:
+        pytest.skip("Skipping because running on CPU instance")
     with _predictor(model_cpu_1d_tar, mnist_1d_script, image_uri, sagemaker_local_session,
                     instance_type) as predictor:
         _assert_prediction_npy_json(predictor, test_loader, content_types.NPY, content_types.JSON)
@@ -76,8 +77,7 @@ def test_serve_cpu_model_on_gpu(test_loader, image_uri, sagemaker_local_session,
 def test_serving_calls_model_fn_once(image_uri, sagemaker_local_session, instance_type):
     with _predictor(call_model_fn_once_tar, call_model_fn_once_script, image_uri, sagemaker_local_session,
                     instance_type, model_server_workers=2) as predictor:
-        predictor.accept = None
-        predictor.deserializer = BytesDeserializer()
+        predictor.deserializer = deserializers.BytesDeserializer()
 
         # call enough times to ensure multiple requests to a worker
         for i in range(3):
@@ -87,14 +87,15 @@ def test_serving_calls_model_fn_once(image_uri, sagemaker_local_session, instanc
 
 
 @contextmanager
-def _predictor(model_tar, script, image, sagemaker_local_session, instance_type,
-               model_server_workers=None):
-    model = PyTorchModel('file://{}'.format(model_tar),
-                         ROLE,
-                         script,
-                         image=image,
-                         sagemaker_session=sagemaker_local_session,
-                         model_server_workers=model_server_workers)
+def _predictor(model_tar, script, image, sagemaker_local_session, instance_type, model_server_workers=None):
+    model = PyTorchModel(
+        model_data='file://{}'.format(model_tar),
+        role=ROLE,
+        entry_point=script,
+        image_uri=image,
+        sagemaker_session=sagemaker_local_session,
+        model_server_workers=model_server_workers
+    )
 
     with local_mode_utils.lock():
         try:
@@ -105,9 +106,7 @@ def _predictor(model_tar, script, image, sagemaker_local_session, instance_type,
 
 
 def _assert_prediction_npy_json(predictor, test_loader, content_type, accept):
-    predictor.content_type = content_type
     predictor.serializer = CONTENT_TYPE_TO_SERIALIZER_MAP[content_type]
-    predictor.accept = accept
     predictor.deserializer = ACCEPT_TYPE_TO_DESERIALIZER_MAP[accept]
 
     data = _get_mnist_batch(test_loader).numpy()
@@ -117,7 +116,6 @@ def _assert_prediction_npy_json(predictor, test_loader, content_type, accept):
 
 
 def _assert_prediction_csv(predictor, test_loader, accept):
-    predictor.accept = accept
     predictor.deserializer = ACCEPT_TYPE_TO_DESERIALIZER_MAP[accept]
 
     data = _get_mnist_batch(test_loader).view(test_loader.batch_size, -1)

--- a/test/integration/local/test_serving.py
+++ b/test/integration/local/test_serving.py
@@ -97,13 +97,14 @@ def test_serving_calls_model_fn_once(image_uri, sagemaker_local_session, instanc
 
 
 @contextmanager
-def _predictor(model_tar, script, image, sagemaker_local_session, instance_type, model_server_workers=None):
+def _predictor(
+    model_tar, script, image, sagemaker_local_session, instance_type, model_server_workers=None, env_vars=None
+):
     if 'gpu' in image:
         env_vars = {
             'NCCL_SHM_DISABLE': '1'
         }
-    else:
-        env_vars = None
+
     model = PyTorchModel(
         model_data='file://{}'.format(model_tar),
         role=ROLE,

--- a/test/integration/sagemaker/test_default_inference.py
+++ b/test/integration/sagemaker/test_default_inference.py
@@ -98,7 +98,7 @@ def _test_default_inference(
         role="SageMakerRole",
         predictor_cls=RealTimePredictor if not accelerator_type else PyTorchPredictor,
         entry_point=mnist_script,
-        image=image_uri,
+        image_uri=image_uri,
         sagemaker_session=sagemaker_session,
     )
     with timeout_and_delete_endpoint(endpoint_name, sagemaker_session, minutes=30):

--- a/test/integration/sagemaker/test_default_inference.py
+++ b/test/integration/sagemaker/test_default_inference.py
@@ -32,8 +32,8 @@ from integration.sagemaker.timeout import timeout_and_delete_endpoint
 
 
 @pytest.mark.cpu_test
-def test_default_inference_cpu(sagemaker_session, image_uri):
-    instance_type = "ml.c4.xlarge"
+def test_default_inference_cpu(sagemaker_session, image_uri, instance_type):
+    instance_type = instance_type or "ml.c4.xlarge"
     # Scripted model is serialized with torch.jit.save().
     # Default inference test doesn't need to instantiate model definition
     _test_default_inference(
@@ -42,8 +42,8 @@ def test_default_inference_cpu(sagemaker_session, image_uri):
 
 
 @pytest.mark.gpu_test
-def test_default_inference_gpu(sagemaker_session, image_uri):
-    instance_type = "ml.p2.xlarge"
+def test_default_inference_gpu(sagemaker_session, image_uri, instance_type):
+    instance_type = instance_type or "ml.p2.xlarge"
     # Scripted model is serialized with torch.jit.save().
     # Default inference test doesn't need to instantiate model definition
     _test_default_inference(
@@ -70,8 +70,8 @@ def test_default_inference_eia(sagemaker_session, image_uri, instance_type, acce
 
 
 @pytest.mark.gpu_test
-def test_default_inference_any_model_name_gpu(sagemaker_session, image_uri):
-    instance_type = "ml.p2.xlarge"
+def test_default_inference_any_model_name_gpu(sagemaker_session, image_uri, instance_type):
+    instance_type = instance_type or "ml.p2.xlarge"
     # Scripted model is serialized with torch.jit.save().
     # Default inference test doesn't need to instantiate model definition
     _test_default_inference(

--- a/test/integration/sagemaker/test_default_inference.py
+++ b/test/integration/sagemaker/test_default_inference.py
@@ -93,6 +93,13 @@ def _test_default_inference(
         key_prefix="sagemaker-pytorch-serving/models",
     )
 
+    if 'gpu' in image_uri:
+        env_vars = {
+            'NCCL_SHM_DISABLE': '1'
+        }
+    else:
+        env_vars = None
+
     pytorch = PyTorchModel(
         model_data=model_data,
         role="SageMakerRole",
@@ -100,6 +107,7 @@ def _test_default_inference(
         entry_point=mnist_script,
         image_uri=image_uri,
         sagemaker_session=sagemaker_session,
+        env=env_vars
     )
     with timeout_and_delete_endpoint(endpoint_name, sagemaker_session, minutes=30):
         predictor = pytorch.deploy(

--- a/test/integration/sagemaker/test_default_inference.py
+++ b/test/integration/sagemaker/test_default_inference.py
@@ -84,7 +84,7 @@ def test_default_inference_any_model_name_gpu(sagemaker_session, image_uri, inst
 
 
 def _test_default_inference(
-    sagemaker_session, image_uri, instance_type, model_tar, mnist_script, accelerator_type=None
+    sagemaker_session, image_uri, instance_type, model_tar, mnist_script, accelerator_type=None, env_vars=None
 ):
     endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-pytorch-serving")
 
@@ -97,8 +97,6 @@ def _test_default_inference(
         env_vars = {
             'NCCL_SHM_DISABLE': '1'
         }
-    else:
-        env_vars = None
 
     pytorch = PyTorchModel(
         model_data=model_data,

--- a/test/integration/sagemaker/test_default_inference.py
+++ b/test/integration/sagemaker/test_default_inference.py
@@ -32,8 +32,8 @@ from integration.sagemaker.timeout import timeout_and_delete_endpoint
 
 
 @pytest.mark.cpu_test
-def test_default_inference_cpu(sagemaker_session, image_uri, instance_type):
-    instance_type = instance_type or "ml.c4.xlarge"
+def test_default_inference_cpu(sagemaker_session, image_uri):
+    instance_type = "ml.c4.xlarge"
     # Scripted model is serialized with torch.jit.save().
     # Default inference test doesn't need to instantiate model definition
     _test_default_inference(
@@ -42,8 +42,8 @@ def test_default_inference_cpu(sagemaker_session, image_uri, instance_type):
 
 
 @pytest.mark.gpu_test
-def test_default_inference_gpu(sagemaker_session, image_uri, instance_type):
-    instance_type = instance_type or "ml.p2.xlarge"
+def test_default_inference_gpu(sagemaker_session, image_uri):
+    instance_type = "ml.p2.xlarge"
     # Scripted model is serialized with torch.jit.save().
     # Default inference test doesn't need to instantiate model definition
     _test_default_inference(
@@ -70,8 +70,8 @@ def test_default_inference_eia(sagemaker_session, image_uri, instance_type, acce
 
 
 @pytest.mark.gpu_test
-def test_default_inference_any_model_name_gpu(sagemaker_session, image_uri, instance_type):
-    instance_type = instance_type or "ml.p2.xlarge"
+def test_default_inference_any_model_name_gpu(sagemaker_session, image_uri):
+    instance_type = "ml.p2.xlarge"
     # Scripted model is serialized with torch.jit.save().
     # Default inference test doesn't need to instantiate model definition
     _test_default_inference(

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -54,7 +54,7 @@ def _test_mnist_distributed(sagemaker_session, image_uri, instance_type, model_t
     )
 
     pytorch = PyTorchModel(model_data=model_data, role='SageMakerRole', entry_point=mnist_script,
-                           image=image_uri, sagemaker_session=sagemaker_session)
+                           image_uri=image_uri, sagemaker_session=sagemaker_session)
     with timeout_and_delete_endpoint(endpoint_name, sagemaker_session, minutes=30):
         # Use accelerator type to differentiate EI vs. CPU and GPU. Don't use processor value
         if accelerator_type is not None:

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -45,7 +45,7 @@ def test_mnist_eia(sagemaker_session, image_uri, instance_type, accelerator_type
 
 
 def _test_mnist_distributed(sagemaker_session, image_uri, instance_type, model_tar, mnist_script,
-                            accelerator_type=None):
+                            accelerator_type=None, env_vars=None):
     endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-pytorch-serving")
 
     model_data = sagemaker_session.upload_data(
@@ -57,8 +57,6 @@ def _test_mnist_distributed(sagemaker_session, image_uri, instance_type, model_t
         env_vars = {
             'NCCL_SHM_DISABLE': '1'
         }
-    else:
-        env_vars = None
 
     pytorch = PyTorchModel(model_data=model_data, role='SageMakerRole', entry_point=mnist_script,
                            image_uri=image_uri, sagemaker_session=sagemaker_session, env=env_vars)

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -23,14 +23,14 @@ from integration.sagemaker.timeout import timeout_and_delete_endpoint
 
 
 @pytest.mark.cpu_test
-def test_mnist_cpu(sagemaker_session, image_uri, instance_type):
-    instance_type = instance_type or 'ml.c4.xlarge'
+def test_mnist_cpu(sagemaker_session, image_uri):
+    instance_type = 'ml.c4.xlarge'
     _test_mnist_distributed(sagemaker_session, image_uri, instance_type, model_cpu_tar, mnist_cpu_script)
 
 
 @pytest.mark.gpu_test
-def test_mnist_gpu(sagemaker_session, image_uri, instance_type):
-    instance_type = instance_type or 'ml.p2.xlarge'
+def test_mnist_gpu(sagemaker_session, image_uri):
+    instance_type = 'ml.p2.xlarge'
     _test_mnist_distributed(sagemaker_session, image_uri, instance_type, model_gpu_tar, mnist_gpu_script)
 
 

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -53,8 +53,15 @@ def _test_mnist_distributed(sagemaker_session, image_uri, instance_type, model_t
         key_prefix="sagemaker-pytorch-serving/models",
     )
 
+    if 'gpu' in image_uri:
+        env_vars = {
+            'NCCL_SHM_DISABLE': '1'
+        }
+    else:
+        env_vars = None
+
     pytorch = PyTorchModel(model_data=model_data, role='SageMakerRole', entry_point=mnist_script,
-                           image_uri=image_uri, sagemaker_session=sagemaker_session)
+                           image_uri=image_uri, sagemaker_session=sagemaker_session, env=env_vars)
     with timeout_and_delete_endpoint(endpoint_name, sagemaker_session, minutes=30):
         # Use accelerator type to differentiate EI vs. CPU and GPU. Don't use processor value
         if accelerator_type is not None:

--- a/test/integration/sagemaker/test_mnist.py
+++ b/test/integration/sagemaker/test_mnist.py
@@ -23,14 +23,14 @@ from integration.sagemaker.timeout import timeout_and_delete_endpoint
 
 
 @pytest.mark.cpu_test
-def test_mnist_cpu(sagemaker_session, image_uri):
-    instance_type = 'ml.c4.xlarge'
+def test_mnist_cpu(sagemaker_session, image_uri, instance_type):
+    instance_type = instance_type or 'ml.c4.xlarge'
     _test_mnist_distributed(sagemaker_session, image_uri, instance_type, model_cpu_tar, mnist_cpu_script)
 
 
 @pytest.mark.gpu_test
-def test_mnist_gpu(sagemaker_session, image_uri):
-    instance_type = 'ml.p2.xlarge'
+def test_mnist_gpu(sagemaker_session, image_uri, instance_type):
+    instance_type = instance_type or 'ml.p2.xlarge'
     _test_mnist_distributed(sagemaker_session, image_uri, instance_type, model_gpu_tar, mnist_gpu_script)
 
 

--- a/test/resources/mnist/model_gpu/code/mnist.py
+++ b/test/resources/mnist/model_gpu/code/mnist.py
@@ -54,4 +54,6 @@ def model_fn(model_dir):
     model = torch.nn.DataParallel(Net())
     with open(os.path.join(model_dir, 'torch_model.pth'), 'rb') as f:
         model.load_state_dict(torch.load(f))
+    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    model = model.to(device)
     return model

--- a/test/resources/mnist/model_gpu/code/mnist.py
+++ b/test/resources/mnist/model_gpu/code/mnist.py
@@ -51,9 +51,16 @@ class Net(nn.Module):
 
 def model_fn(model_dir):
     logger.info('model_fn')
+    
+    # Check if CUDA (GPU support) is available
+    if not torch.cuda.is_available():
+        raise EnvironmentError("CUDA (GPU) is not available. This model requires GPU support.")
+    
     model = torch.nn.DataParallel(Net())
     with open(os.path.join(model_dir, 'torch_model.pth'), 'rb') as f:
         model.load_state_dict(torch.load(f))
-    device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    
+    # Move the model to the GPU
+    device = torch.device("cuda")
     model = model.to(device)
     return model

--- a/tox.ini
+++ b/tox.ini
@@ -72,14 +72,14 @@ deps =
     protobuf
 
 [testenv:flake8]
-basepython = python3
+basepython = python3.8
 deps =
     flake8
     flake8-future-import
 commands = flake8
 
 [testenv:twine]
-basepython = python3
+basepython = python3.8
 # https://github.com/pypa/twine/blob/master/docs/changelog.rst
 deps =
     twine>=1.12.0

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,py36,py37
+envlist = flake8,py38,py39,py310
 skip_missing_interpreters = False
 
 [flake8]
@@ -21,7 +21,7 @@ exclude =
 max-complexity = 10
 ignore =
     C901,
-    E203,  # whitespace before ':': Black disagrees with and explicitly violates this.
+    E203,  
     FI10,
     FI12,
     FI13,
@@ -29,7 +29,7 @@ ignore =
     FI15,
     FI16,
     FI17,
-    FI18,  # __future__ import "annotations" missing -> check only Python 3.7 compatible
+    FI18,  
     FI50,
     FI51,
     FI52,
@@ -60,17 +60,16 @@ deps =
     pytest-cov
     pytest-xdist
     mock
-    requests == 2.20.0
-    urllib3 < 1.23, >= 1.21
-    sagemaker < 2
-    sagemaker-containers
+    requests
+    urllib3
+    sagemaker == 2.125.0
     torch
     torchvision
     retrying
     six
     future
-    pyyaml
-    protobuf == 3.19.6
+    PyYaml
+    protobuf
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

**Note**: For more details about changes in SageMaker Python SDK from v1 to v2, please refer to this [link](https://sagemaker.readthedocs.io/en/stable/v2.html).

The following files need to be updated:

- [setup.py](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/setup.py): 
    - Update the `classifiers` in `setup` to update the Python versions to Python 3.8, 3.9 and 3.10.
    - Update the test dependencies to use later versions and remove `sagemaker-containers`.
- test/container/2.0.1/:
    - Create a CPU DLC Dockerfile with the PyTorch 2.0.1 TorchServe SageMaker DLC image and install the PyTorch inference toolkit binary (similar to [test/container/1.10.2/Dockerfile.dlc.cpu](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/test/container/1.10.2/Dockerfile.dlc.cpu)). 
    - Create a GPU DLC Dockerfile with PyTorch 2.0.1 TorchServe SageMaker DLC image and install the PyTorch inference toolkit binary (similar to [test/container/1.10.2/Dockerfile.dlc.gpu](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/test/container/1.10.2/Dockerfile.dlc.gpu)).
- [tox.ini](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/tox.ini):
    - Change `envlist` to remove `py36`,`py37` and add `py38`,`py39`,`py310`.
    - Update the test dependencies to use later versions and remove `sagemaker-containers`.
    - Removed comments starting with `#` to pass `flake8` check.
- [test/integration/local/test_serving.py](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/test/integration/local/test_serving.py):
    - Update import statements.
        - Import `serializers` and `deserializers` from `sagemaker`.
        - Import `content_types` from `sagemaker_inference`.  
    - Update `CONTENT_TYPE_TO_SERIALIZER_MAP` and `ACCEPT_TYPE_TO_SERIALIZER_MAP`.
    - In `PyTorchModel` , replace `image` with `image_uri` (SageMaker Python SDK v2 has replaced the argument name `image` with `image_uri`).
    - Remove lines like these (not supported by SageMaker Python SDK v2):
```
predictor.content_type = content_type
predictor.accept = accept
```
- [test/integration/sagemaker/test_default_inference.py](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/test/integration/sagemaker/test_default_inference.py):
    - In `PyTorchModel`, replace `image` with `image_uri`.
- [test/integration/sagemaker/test_mnist.py](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/test/integration/sagemaker/test_mnist.py):
    - In `PyTorchModel` , replace `image` with `image_uri`.
- [buildspec.yml](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/buildspec.yml):
    - Change `FRAMEWORK_VERSION` to `2.0.1`.
    - Update `SETUP_CMDS` to use Python 3.8 instead of Python 3.6. 
    - Update Python versions for unit tests from `py36`,`py37` to `py38`,`py39`,`py310`.
    - Update Python version for all integration tests from `py36` to `py38`.
    - Launch GPU EC2 instance with an AMI which has Python 3.8 installed, for example `ami-03e3ef8c92fdb39ad`.
    - Run remote test command with with Python version 3.8.
- [test/resources/mnist/model_gpu/code/mnist.py](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/test/resources/mnist/model_gpu/code/mnist.py):
    - Update `model_fn` to load model on GPU.
```
device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
model = model.to(device)
```
- [buildspec-release.yml](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/buildspec-release.yml):
    - Update Python versions for unit tests from `py36`,`py37` to `py38`,`py39`,`py310`.
- [src/sagemaker_pytorch_serving_container/default_pytorch_inference_handler.py](https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/master/src/sagemaker_pytorch_serving_container/default_pytorch_inference_handler.py):
    - In `default_output_fn`, check type of `prediction` with `is` instead of `==` to pass `flake8` check. 
 
----------------------------------------------------------------------------------------------------------------------------

**UPDATE**: 

- Updated GPU instance type to `g4dn.12xlarge` from `p3.8xlarge` since the latter is often unavailable in the `us-west-2` region.
- Added GPU and CPU Dockerfiles for PyTorch 2.0.0 as well (since this version is also currently supported by DLC team)
- Updated `buildspec.yml` to run integration tests for both frameworks i.e. `2.0.0` and `2.0.1`.
- EIA is no longer an active project for the DLC team (https://github.com/aws/deep-learning-containers/pull/2466). The last image released by them is `763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference-eia:1.5.1-cpu-py38-ubuntu20.04`. Commented out EIA test commands in `buildspec.yml` since they lead to errors while building the EIA image (pinned `numpy` version is not available in the base image which is used to build the `EIA` image). Building this image is of no use since these are anyways skipped due to this condition:
```
@pytest.mark.skip(
    reason="Latest EIA version - 1.5.1 uses mms. Enable when EIA images use torchserve"
``` 
- Included the environment variable `NCCL_SHM_DISABLE=1` while creating the SageMaker endpoint for GPU tests to avoid this error:
```
NCCL Error 2: unhandled system error
Traceback (most recent call last):
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_inference/transformer.py", line 142, in transform
    result = self._run_handler_function(
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_inference/transformer.py", line 276, in _run_handler_function
    result = func(*argv_context)
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_inference/transformer.py", line 260, in _default_transform_fn
    prediction = self._run_handler_function(self._predict_fn, *(data, model))
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_inference/transformer.py", line 272, in _run_handler_function
    result = func(*argv)
  File "/opt/conda/lib/python3.8/site-packages/sagemaker_pytorch_serving_container/default_pytorch_inference_handler.py", line 125, in default_predict_fn
    output = model(input_data)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1102, in _call_impl
    return forward_call(*input, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/data_parallel.py", line 167, in forward
    replicas = self.replicate(self.module, self.device_ids[:len(inputs)])
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/data_parallel.py", line 172, in replicate
    return replicate(module, device_ids, not torch.is_grad_enabled())
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/replicate.py", line 91, in replicate
    param_copies = _broadcast_coalesced_reshape(params, devices, detach)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/replicate.py", line 67, in _broadcast_coalesced_reshape
    return comm.broadcast_coalesced(tensors, devices)
  File "/opt/conda/lib/python3.8/site-packages/torch/nn/parallel/comm.py", line 58, in broadcast_coalesced
    return torch._C._broadcast_coalesced(tensors, devices, buffer_size)
RuntimeError: NCCL Error 2: unhandled system error
```
Please note that this error is specifically related to `torch.nn.DataParallel` (https://github.com/pytorch/pytorch/issues/73775) which is used while creating the MNIST model. It causes the worker to die and leads to error code 500. Please note that this issue does not come up when running the same tests on a `g4dn.xlarge` EC2 instance.
- Pinned the versions of the dependencies in `setup.py`.
- Change default versions of `--dockerfile-type` and `--framework-version` in `conftest.py`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
