### PR TITLE
Unpin dependency versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,8 +52,8 @@ setup(
 
     # We don't declare our dependency on torch here because we build with
     # different packages for different variants
-    install_requires=['boto3==1.28.60', 'numpy==1.24.4', 'six==1.16.0',
-                      'retrying==1.3.4', 'scipy==1.10.1', 'psutil==5.9.5'],
+    install_requires=['boto3>=1.28.60', 'numpy>=1.24.4', 'six>=1.16.0',
+                      'retrying>=1.3.4', 'scipy>=1.10.1', 'psutil>=5.9.5'],
     extras_require={
         'test': ['coverage==7.3.2', 'docker-compose==1.29.2', 'flake8==6.1.0', 'Flask==3.0.0',
                  'mock==5.1.0', 'pytest==7.4.2', 'pytest-cov==4.1.0', 'pytest-xdist==3.3.1',

--- a/tox.ini
+++ b/tox.ini
@@ -52,21 +52,31 @@ commands =
     {env:IGNORE_COVERAGE:} coverage report --fail-under=90
 
 deps =
+    boto3
     coverage
+    urllib3>=1.25.4,<1.27
+    Flask==1.1.1
+    fabric
+    flake8==3.7.7
+    gitpython
+    invoke
+    mock
+    numpy
+    Pillow
+    packaging
     pytest
     pytest-cov
+    pytest-rerunfailures
     pytest-xdist
-    mock
     requests
-    urllib3
-    sagemaker == 2.125.0
+    requests_mock
+    retrying==1.3.3
+    sagemaker>=2,<3
+    six
+    tenacity
+    toml
     torch
     torchvision
-    retrying
-    six
-    future
-    PyYaml
-    protobuf
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Creating this PR to unpin the dependency versions in `setup.py` since pinning is causing pip check failures in the DLC image build. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
