### PR TITLE
Ignore zombie processes when detecting TorchServe status

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    FRAMEWORK_VERSIONS: '2.0.0 2.0.1'
+    FRAMEWORK_VERSIONS: '2.1.0 2.2.0'
     CPU_INSTANCE_TYPE: 'ml.c4.xlarge'
     GPU_INSTANCE_TYPE: 'ml.g4dn.12xlarge'
     ECR_REPO: 'sagemaker-test'

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ env:
   variables:
     FRAMEWORK_VERSIONS: '2.1.0 2.2.0'
     CPU_INSTANCE_TYPE: 'ml.c4.xlarge'
-    GPU_INSTANCE_TYPE: 'ml.g4dn.12xlarge'
+    GPU_INSTANCE_TYPE: 'ml.g5.12xlarge'
     ECR_REPO: 'sagemaker-test'
     GITHUB_REPO: 'sagemaker-pytorch-serving-container'
     DLC_ACCOUNT: '763104351884'

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ env:
   variables:
     FRAMEWORK_VERSIONS: '2.1.0 2.2.0'
     CPU_INSTANCE_TYPE: 'ml.c4.xlarge'
-    GPU_INSTANCE_TYPE: 'ml.g5.12xlarge'
+    GPU_INSTANCE_TYPE: 'ml.g4dn.12xlarge'
     ECR_REPO: 'sagemaker-test'
     GITHUB_REPO: 'sagemaker-pytorch-serving-container'
     DLC_ACCOUNT: '763104351884'

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -49,12 +49,12 @@ phases:
       - $(aws ecr get-login --registry-ids $DLC_ACCOUNT --no-include-email --region $AWS_DEFAULT_REGION)
       - create-key-pair
       
-      # launch remote GPU instance with Deep Learning AMI GPU PyTorch 1.9 (Ubuntu 20.04)
+      # launch remote GPU instance with Deep Learning AMI GPU PyTorch 2.2 (Ubuntu 20.04)
       # build DLC GPU image because the base DLC image is too big and takes too long to build as part of the test
       - |
         for FRAMEWORK_VERSION in $FRAMEWORK_VERSIONS;
           do
-            launch-ec2-instance --instance-type $instance_type --ami-name ami-03e3ef8c92fdb39ad;
+            launch-ec2-instance --instance-type $instance_type --ami-name ami-081c4092fbff425f0;
             DLC_GPU_TAG="$FRAMEWORK_VERSION-dlc-gpu-$BUILD_ID";
             build_dir="test/container/$FRAMEWORK_VERSION";
             docker build -f "$build_dir/Dockerfile.dlc.gpu" -t $PREPROD_IMAGE:$DLC_GPU_TAG --build-arg region=$AWS_DEFAULT_REGION .;

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -184,11 +184,11 @@ def _retrieve_ts_server_process():
     ts_server_processes = list()
 
     for process in psutil.process_iter():
-        try:
-            if TS_NAMESPACE in process.cmdline():
-                ts_server_processes.append(process)
-        except psutil.NoSuchProcess:
+        if process.status() == psutil.STATUS_ZOMBIE:
             continue
+
+        if TS_NAMESPACE in process.cmdline():
+            ts_server_processes.append(process)
 
     if not ts_server_processes:
         raise Exception("Torchserve model server was unsuccessfully started")

--- a/src/sagemaker_pytorch_serving_container/torchserve.py
+++ b/src/sagemaker_pytorch_serving_container/torchserve.py
@@ -184,8 +184,11 @@ def _retrieve_ts_server_process():
     ts_server_processes = list()
 
     for process in psutil.process_iter():
-        if TS_NAMESPACE in process.cmdline():
-            ts_server_processes.append(process)
+        try:
+            if TS_NAMESPACE in process.cmdline():
+                ts_server_processes.append(process)
+        except psutil.NoSuchProcess:
+            continue
 
     if not ts_server_processes:
         raise Exception("Torchserve model server was unsuccessfully started")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,7 +52,7 @@ def pytest_addoption(parser):
     parser.addoption('--instance-type')
     parser.addoption('--docker-base-name', default='sagemaker-pytorch-inference')
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default="2.0.0")
+    parser.addoption('--framework-version', default="2.1.0")
     parser.addoption('--py-version', choices=['2', '3'], default='3')
     parser.addoption('--processor', choices=['gpu', 'cpu'], default='cpu')
     # If not specified, will default to {framework-version}-{processor}-py{py-version}

--- a/test/container/2.1.0/Dockerfile.dlc.cpu
+++ b/test/container/2.1.0/Dockerfile.dlc.cpu
@@ -1,5 +1,5 @@
 ARG region
-FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.0-gpu-py310-cu118-ubuntu20.04-sagemaker
+FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.1.0-cpu-py310-ubuntu20.04-sagemaker
 
 COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
 

--- a/test/container/2.1.0/Dockerfile.dlc.gpu
+++ b/test/container/2.1.0/Dockerfile.dlc.gpu
@@ -1,5 +1,5 @@
 ARG region
-FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.0-cpu-py310-ubuntu20.04-sagemaker
+FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.1.0-gpu-py310-cu118-ubuntu20.04-sagemaker
 
 COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
 

--- a/test/container/2.2.0/Dockerfile.dlc.cpu
+++ b/test/container/2.2.0/Dockerfile.dlc.cpu
@@ -1,5 +1,5 @@
 ARG region
-FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.1-cpu-py310-ubuntu20.04-sagemaker
+FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.2.0-cpu-py310-ubuntu20.04-sagemaker
 
 COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
 

--- a/test/container/2.2.0/Dockerfile.dlc.gpu
+++ b/test/container/2.2.0/Dockerfile.dlc.gpu
@@ -1,5 +1,5 @@
 ARG region
-FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.0.1-gpu-py310-cu118-ubuntu20.04-sagemaker
+FROM 763104351884.dkr.ecr.$region.amazonaws.com/pytorch-inference:2.2.0-gpu-py310-cu118-ubuntu20.04-sagemaker
 
 COPY dist/sagemaker_pytorch_inference-*.tar.gz /sagemaker_pytorch_inference.tar.gz
 

--- a/test/integration/sagemaker/test_multi_model_endpoint_sagemaker.py
+++ b/test/integration/sagemaker/test_multi_model_endpoint_sagemaker.py
@@ -49,7 +49,7 @@ def fixture_mme_endpoint(
     sagemaker_session, image_uri, region, use_gpu, resnet18_filename, traced_resnet18_filename, s3, bucket
 ):
     try:
-        instance_type = 'ml.g5.xlarge' if use_gpu else 'ml.c5.xlarge'
+        instance_type = 'ml.g4dn.xlarge' if use_gpu else 'ml.c5.xlarge'
         endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-pytorch-serving")
 
         model_data = sagemaker_session.upload_data(

--- a/test/integration/sagemaker/test_multi_model_endpoint_sagemaker.py
+++ b/test/integration/sagemaker/test_multi_model_endpoint_sagemaker.py
@@ -49,7 +49,7 @@ def fixture_mme_endpoint(
     sagemaker_session, image_uri, region, use_gpu, resnet18_filename, traced_resnet18_filename, s3, bucket
 ):
     try:
-        instance_type = 'ml.g4dn.xlarge' if use_gpu else 'ml.c5.xlarge'
+        instance_type = 'ml.g5.xlarge' if use_gpu else 'ml.c5.xlarge'
         endpoint_name = sagemaker.utils.unique_name_from_base("sagemaker-pytorch-serving")
 
         model_data = sagemaker_session.upload_data(


### PR DESCRIPTION
*Description of changes:*
When checking to see if the TorchServe process is running, we iterate through the current list of running processes using `psutil`:
https://github.com/aws/sagemaker-pytorch-inference-toolkit/blob/36a842e374766a088f21906ce17496e88a140a1b/src/sagemaker_pytorch_serving_container/torchserve.py#L183-L188

Calling the `command()` psutil API on a zombie process raises the `psutil.ZombieProcess` exception. This unhandled exception causes TorchServe to be stopped which is not expected behavior in DLC: https://github.com/aws/deep-learning-containers/tree/master/pytorch/inference

```
  File "/opt/conda/lib/python3.10/site-packages/sagemaker_pytorch_serving_container/torchserve.py", line 187, in _retrieve_ts_server_process
    if TS_NAMESPACE in process.cmdline():
  File "/opt/conda/lib/python3.10/site-packages/psutil/__init__.py", line 719, in cmdline
    raise ImportError(msg)
  File "/opt/conda/lib/python3.10/site-packages/psutil/_pslinux.py", line 1714, in wrapper
    ret['name'] = name
  File "/opt/conda/lib/python3.10/site-packages/psutil/_pslinux.py", line 1853, in cmdline
    stime = float(values['stime']) / CLOCK_TICKS
  File "/opt/conda/lib/python3.10/site-packages/psutil/_pslinux.py", line 1758, in _raise_if_zombie
    name = decode(name)
psutil.ZombieProcess: PID still exists but it's a zombie (pid=9)
```

We can ignore zombie processes when detecting the presence of a running TorchServe process. Reference: https://psutil.readthedocs.io/en/latest/#psutil.ZombieProcess

Tests:
- CI
- Manual testing
  - Without the fix in this PR
```
$ docker run --name sagemaker_pt_dlc  -p 8080:8080 --mount type=bind,source=/home/ubuntu/dlc_test/dump,target=/opt/ml/model -v /home/ubuntu/dlc_test/dump:/hostfs -e SAGEMAKER_NGINX_PROXY_READ_TIMEOUT_SECONDS=600 -e SAGEMAKER_MODEL_SERVER_WORKERS=1 -e OMP_NUM_THREADS=1 -e DNNL_VERBOSE=1 763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference:2.1.0-cpu-py310-ubuntu20.04-sagemaker serve
.....
.....
2024-05-31T17:49:14,665 [INFO ] W-9000-model_1.0 TS_METRICS - WorkerLoadTime.Milliseconds:2257.0|#WorkerName:W-9000-model_1.0,Level:Host|#hostname:c988cd31b0a0,timestamp:1717177754
2024-05-31T17:49:14,665 [INFO ] W-9000-model_1.0 TS_METRICS - WorkerThreadTime.Milliseconds:3.0|#Level:Host|#hostname:c988cd31b0a0,timestamp:1717177754
['torchserve', '--start', '--model-store', '/.sagemaker/ts/models', '--ts-config', '/etc/sagemaker-ts.properties', '--log-config', '/opt/conda/lib/python3.10/site-packages/sagemaker_pytorch_serving_container/etc/log4j2.xml', '--models', 'model=/opt/ml/model']
Traceback (most recent call last):
  File "/usr/local/bin/dockerd-entrypoint.py", line 23, in <module>
    serving.main()
  File "/opt/conda/lib/python3.10/site-packages/sagemaker_pytorch_serving_container/serving.py", line 38, in main
    _start_torchserve()
  File "/opt/conda/lib/python3.10/site-packages/retrying.py", line 56, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/opt/conda/lib/python3.10/site-packages/retrying.py", line 257, in call
    return attempt.get(self._wrap_exception)
  File "/opt/conda/lib/python3.10/site-packages/retrying.py", line 301, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/opt/conda/lib/python3.10/site-packages/six.py", line 719, in reraise
    raise value
  File "/opt/conda/lib/python3.10/site-packages/retrying.py", line 251, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/opt/conda/lib/python3.10/site-packages/sagemaker_pytorch_serving_container/serving.py", line 34, in _start_torchserve
    torchserve.start_torchserve(handler_service=HANDLER_SERVICE)
  File "/opt/conda/lib/python3.10/site-packages/sagemaker_pytorch_serving_container/torchserve.py", line 102, in start_torchserve
    ts_process = _retrieve_ts_server_process()
  File "/opt/conda/lib/python3.10/site-packages/retrying.py", line 56, in wrapped_f
    return Retrying(*dargs, **dkw).call(f, *args, **kw)
  File "/opt/conda/lib/python3.10/site-packages/retrying.py", line 266, in call
    raise attempt.get()
  File "/opt/conda/lib/python3.10/site-packages/retrying.py", line 301, in get
    six.reraise(self.value[0], self.value[1], self.value[2])
  File "/opt/conda/lib/python3.10/site-packages/six.py", line 719, in reraise
    raise value
  File "/opt/conda/lib/python3.10/site-packages/retrying.py", line 251, in call
    attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
  File "/opt/conda/lib/python3.10/site-packages/sagemaker_pytorch_serving_container/torchserve.py", line 187, in _retrieve_ts_server_process
    if TS_NAMESPACE in process.cmdline():
  File "/opt/conda/lib/python3.10/site-packages/psutil/__init__.py", line 719, in cmdline
    return self._proc.cmdline()
  File "/opt/conda/lib/python3.10/site-packages/psutil/_pslinux.py", line 1714, in wrapper
    return fun(self, *args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/psutil/_pslinux.py", line 1853, in cmdline
    self._raise_if_zombie()
  File "/opt/conda/lib/python3.10/site-packages/psutil/_pslinux.py", line 1758, in _raise_if_zombie
    raise ZombieProcess(self.pid, self._name, self._ppid)
psutil.ZombieProcess: PID still exists but it's a zombie (pid=10)
```
  - With the fix in this PR
```
$ docker run -it 763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-inference:2.1.0-cpu-py310-ubuntu20.04-sagemaker /bin/bash
$ git clone https://github.com/namannandan/sagemaker-pytorch-inference-toolkit.git
$ cd sagemaker-pytorch-inference-toolkit
$ git checkout psutil-zombie-fix
$ pip install .
.....
$ docker container commit ca81ce0ac2c7 test:psutil-fix
$ docker run --name sagemaker_pt_dlc  -p 8080:8080 --mount type=bind,source=/home/ubuntu/dlc_test/dump,target=/opt/ml/model -v /home/ubuntu/dlc_test/dump:/hostfs -e SAGEMAKER_NGINX_PROXY_READ_TIMEOUT_SECONDS=600 -e SAGEMAKER_MODEL_SERVER_WORKERS=1 -e OMP_NUM_THREADS=1 -e DNNL_VERBOSE=1 test:psutil-fix serve
.....
.....
2024-05-31T18:00:40,498 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Torch worker started.
2024-05-31T18:00:40,499 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Python runtime: 3.10.9
2024-05-31T18:00:40,502 [INFO ] W-9000-model_1.0 org.pytorch.serve.wlm.WorkerThread - Connecting to: /home/model-server/tmp/.ts.sock.9000
2024-05-31T18:00:40,507 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - Connection accepted: /home/model-server/tmp/.ts.sock.9000.
2024-05-31T18:00:40,511 [INFO ] W-9000-model_1.0 org.pytorch.serve.wlm.WorkerThread - Looping backend response at: 1717178440511
2024-05-31T18:00:40,537 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - model_name: model, batchSize: 1
2024-05-31T18:00:41,286 [WARN ] W-9000-model_1.0-stderr MODEL_LOG - /opt/conda/lib/python3.10/site-packages/torch/_utils.py:831: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
2024-05-31T18:00:41,287 [WARN ] W-9000-model_1.0-stderr MODEL_LOG -   return self.fget.__get__(instance, owner)()
2024-05-31T18:00:41,456 [WARN ] W-9000-model_1.0-stderr MODEL_LOG - /opt/conda/lib/python3.10/site-packages/transformers/pipelines/text_classification.py:104: UserWarning: `return_all_scores` is now deprecated,  if want a similar functionality use `top_k=None` instead of `return_all_scores=True` or `top_k=1` instead of `return_all_scores=False`.
2024-05-31T18:00:41,456 [WARN ] W-9000-model_1.0-stderr MODEL_LOG -   warnings.warn(
2024-05-31T18:00:41,460 [INFO ] W-9000-model_1.0 org.pytorch.serve.wlm.WorkerThread - Backend response time: 949
2024-05-31T18:00:41,461 [INFO ] W-9000-model_1.0 TS_METRICS - WorkerLoadTime.Milliseconds:2217.0|#WorkerName:W-9000-model_1.0,Level:Host|#hostname:09c62ecb1844,timestamp:1717178441
2024-05-31T18:00:41,461 [INFO ] W-9000-model_1.0 TS_METRICS - WorkerThreadTime.Milliseconds:3.0|#Level:Host|#hostname:09c62ecb1844,timestamp:1717178441
2024-05-31T18:01:39,547 [INFO ] pool-3-thread-1 TS_METRICS - CPUUtilization.Percent:0.0|#Level:Host|#hostname:09c62ecb1844,timestamp:1717178499
2024-05-31T18:01:39,548 [INFO ] pool-3-thread-1 TS_METRICS - DiskAvailable.Gigabytes:456.5026435852051|#Level:Host|#hostname:09c62ecb1844,timestamp:1717178499
2024-05-31T18:01:39,548 [INFO ] pool-3-thread-1 TS_METRICS - DiskUsage.Gigabytes:39.51191711425781|#Level:Host|#hostname:09c62ecb1844,timestamp:1717178499
2024-05-31T18:01:39,548 [INFO ] pool-3-thread-1 TS_METRICS - DiskUtilization.Percent:8.0|#Level:Host|#hostname:09c62ecb1844,timestamp:1717178499
2024-05-31T18:01:39,549 [INFO ] pool-3-thread-1 TS_METRICS - MemoryAvailable.Megabytes:61538.0625|#Level:Host|#hostname:09c62ecb1844,timestamp:1717178499
2024-05-31T18:01:39,549 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUsed.Megabytes:1350.4765625|#Level:Host|#hostname:09c62ecb1844,timestamp:1717178499
2024-05-31T18:01:39,549 [INFO ] pool-3-thread-1 TS_METRICS - MemoryUtilization.Percent:3.3|#Level:Host|#hostname:09c62ecb1844,timestamp:1717178499
.....
.....
```
Torchserve continues to run and container does not get terminated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
