### PR TITLE
Disabling token auth and enabling model API by default

### DIFF
--- a/src/sagemaker_pytorch_serving_container/etc/default-ts.properties
+++ b/src/sagemaker_pytorch_serving_container/etc/default-ts.properties
@@ -3,3 +3,5 @@ vmargs=-XX:-UseContainerSupport
 enable_envvars_config=true
 decode_input_request=false
 load_models=ALL
+disable_token_authorization=true
+enable_model_api=true

--- a/src/sagemaker_pytorch_serving_container/etc/mme-ts.properties
+++ b/src/sagemaker_pytorch_serving_container/etc/mme-ts.properties
@@ -5,3 +5,5 @@ default_service_handler=$$SAGEMAKER_HANDLER$$
 default_workers_per_model=1
 async_logging=true
 decode_input_request=false
+disable_token_authorization=true
+enable_model_api=true


### PR DESCRIPTION
Disabling token auth and enabling model API by default for DLC since access to the endpoint will be restricted by IAM. 