### PR TITLE
Add functionality to configure TorchServe logging levels using the TS_LOG_LEVEL environment variable.

### DIFF
--- a/src/sagemaker_pytorch_serving_container/serving.py
+++ b/src/sagemaker_pytorch_serving_container/serving.py
@@ -34,15 +34,23 @@ def configure_logging():
     }
 
     ts_loglevel = os.environ.get('TS_LOGLEVEL')
+    log4j2_path = 'etc/log4j2.xml'
+
+    print(f"Current working directory: {os.getcwd()}")
+    print(f"log4j2.xml path: {os.path.abspath(log4j2_path)}")
+
+    if not os.path.exists(log4j2_path):
+        print(f"Error: {log4j2_path} does not exist", file=sys.stderr)
+        return
 
     if ts_loglevel is not None:
         if ts_loglevel in log_levels:
             try:
                 log_level = log_levels[ts_loglevel]
-                subprocess.run(['sed', '-i', f's/info/{log_level}/g', 'etc/log4j2.xml'], check=True)
+                subprocess.run(['sed', '-i', f's/info/{log_level}/g', log4j2_path], check=True)
                 print(f"Logging level set to {log_level}")
-            except subprocess.CalledProcessError:
-                print("Error configuring the logging", file=sys.stderr)
+            except subprocess.CalledProcessError as e:
+                print(f"Error configuring the logging: {e}", file=sys.stderr)
         else:
             print(f"Invalid TS_LOGLEVEL value: {ts_loglevel}. No changes made to logging configuration.", file=sys.stderr)
     else:

--- a/src/sagemaker_pytorch_serving_container/serving.py
+++ b/src/sagemaker_pytorch_serving_container/serving.py
@@ -12,6 +12,8 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
+import os
+import subprocess
 from subprocess import CalledProcessError
 
 from retrying import retry
@@ -20,10 +22,34 @@ from sagemaker_pytorch_serving_container import handler_service
 
 HANDLER_SERVICE = handler_service.__file__
 
+def configure_logging():
+    log_levels = {
+        '0': 'off',
+        '10': 'fatal',
+        '20': 'error',
+        '30': 'warn',
+        '40': 'info',
+        '50': 'debug',
+        '60': 'trace'
+    }
+
+    ts_loglevel = os.environ.get('TS_LOGLEVEL')
+
+    if ts_loglevel is not None:
+        if ts_loglevel in log_levels:
+            try:
+                log_level = log_levels[ts_loglevel]
+                subprocess.run(['sed', '-i', f's/info/{log_level}/g', 'etc/log4j2.xml'], check=True)
+                print(f"Logging level set to {log_level}")
+            except subprocess.CalledProcessError:
+                print("Error configuring the logging", file=sys.stderr)
+        else:
+            print(f"Invalid TS_LOGLEVEL value: {ts_loglevel}. No changes made to logging configuration.", file=sys.stderr)
+    else:
+        print("TS_LOGLEVEL not set. Using default logging configuration.")
 
 def _retry_if_error(exception):
     return isinstance(exception, CalledProcessError)
-
 
 @retry(stop_max_delay=1000 * 30,
        retry_on_exception=_retry_if_error)
@@ -33,6 +59,9 @@ def _start_torchserve():
     # retry starting mms until it's ready
     torchserve.start_torchserve(handler_service=HANDLER_SERVICE)
 
-
 def main():
+    configure_logging()
     _start_torchserve()
+
+if __name__ == '__main__':
+    main()

--- a/src/sagemaker_pytorch_serving_container/serving.py
+++ b/src/sagemaker_pytorch_serving_container/serving.py
@@ -35,9 +35,9 @@ def configure_logging():
 
     # Get the directory of the current script
     current_script_path = os.path.abspath(__file__)
-    current_dir = os.path.dirname(current_script_path)
+    
     # Construct the path to log4j2.xml relative to the script location
-    log4j2_path = os.path.join(os.path.dirname(current_dir), 'etc', 'log4j2.xml')
+    log4j2_path = os.path.join(os.path.dirname(current_script_path), 'etc', 'log4j2.xml')
 
     print(f"Current script path: {current_script_path}")
     print(f"log4j2.xml path: {log4j2_path}")

--- a/src/sagemaker_pytorch_serving_container/serving.py
+++ b/src/sagemaker_pytorch_serving_container/serving.py
@@ -12,7 +12,7 @@
 # language governing permissions and limitations under the License.
 from __future__ import absolute_import
 
-import os
+import os,sys
 import subprocess
 from subprocess import CalledProcessError
 

--- a/src/sagemaker_pytorch_serving_container/serving.py
+++ b/src/sagemaker_pytorch_serving_container/serving.py
@@ -33,15 +33,20 @@ def configure_logging():
         '60': 'trace'
     }
 
-    ts_loglevel = os.environ.get('TS_LOGLEVEL')
-    log4j2_path = 'etc/log4j2.xml'
+    # Get the directory of the current script
+    current_script_path = os.path.abspath(__file__)
+    current_dir = os.path.dirname(current_script_path)
+    # Construct the path to log4j2.xml relative to the script location
+    log4j2_path = os.path.join(os.path.dirname(current_dir), 'etc', 'log4j2.xml')
 
-    print(f"Current working directory: {os.getcwd()}")
-    print(f"log4j2.xml path: {os.path.abspath(log4j2_path)}")
+    print(f"Current script path: {current_script_path}")
+    print(f"log4j2.xml path: {log4j2_path}")
 
     if not os.path.exists(log4j2_path):
         print(f"Error: {log4j2_path} does not exist", file=sys.stderr)
         return
+
+    ts_loglevel = os.environ.get('TS_LOGLEVEL')
 
     if ts_loglevel is not None:
         if ts_loglevel in log_levels:

--- a/src/sagemaker_pytorch_serving_container/serving.py
+++ b/src/sagemaker_pytorch_serving_container/serving.py
@@ -47,20 +47,20 @@ def configure_logging():
         print(f"Error: {log4j2_path} does not exist", file=sys.stderr)
         return
 
-    ts_loglevel = os.environ.get('TS_LOGLEVEL')
+    ts_log_level = os.environ.get('TS_LOG_LEVEL')
 
-    if ts_loglevel is not None:
-        if ts_loglevel in log_levels:
+    if ts_log_level is not None:
+        if ts_log_level in log_levels:
             try:
-                log_level = log_levels[ts_loglevel]
+                log_level = log_levels[ts_log_level]
                 subprocess.run(['sed', '-i', f's/info/{log_level}/g', log4j2_path], check=True)
                 print(f"Logging level set to {log_level}")
             except subprocess.CalledProcessError as e:
                 print(f"Error configuring the logging: {e}", file=sys.stderr)
         else:
-            print(f"Invalid TS_LOGLEVEL value: {ts_loglevel}. No changes made to logging configuration.", file=sys.stderr)
+            print(f"Invalid TS_LOG_LEVEL value: {ts_log_level}. No changes made to logging configuration.", file=sys.stderr)
     else:
-        print("TS_LOGLEVEL not set. Using default logging configuration.")
+        print("TS_LOG_LEVEL not set. Using default logging configuration.")
 
 def _retry_if_error(exception):
     return isinstance(exception, CalledProcessError)

--- a/src/sagemaker_pytorch_serving_container/serving.py
+++ b/src/sagemaker_pytorch_serving_container/serving.py
@@ -22,6 +22,7 @@ from sagemaker_pytorch_serving_container import handler_service
 
 HANDLER_SERVICE = handler_service.__file__
 
+## added logging function to configure log4j2 loglevel.
 def configure_logging():
     log_levels = {
         '0': 'off',

--- a/test/unit/test_log_config.py
+++ b/test/unit/test_log_config.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+from sagemaker_pytorch_serving_container.serving import configure_log_level
+
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+from your_module import configure_log_level  # replace 'your_module' with the actual module name
+
+class TestLogConfig(unittest.TestCase):
+
+    @patch('os.environ.get')
+    @patch('subprocess.run')
+    def test_valid_log_level(self, mock_run, mock_env_get):
+        mock_env_get.return_value = '20'
+        mock_run.return_value = MagicMock(returncode=0)
+        
+        result = configure_log_level()
+        
+        self.assertEqual(result, "Logging level set to error")
+        mock_run.assert_called_once()
+
+    @patch('os.environ.get')
+    def test_invalid_log_level(self, mock_env_get):
+        mock_env_get.return_value = '70'
+        
+        result = configure_log_level()
+        
+        self.assertEqual(result, "Invalid TS_LOGLEVEL value: 70. No changes made to logging configuration.")
+
+    @patch('os.environ.get')
+    def test_no_log_level_set(self, mock_env_get):
+        mock_env_get.return_value = None
+        
+        result = configure_log_level()
+        
+        self.assertEqual(result, "TS_LOGLEVEL not set. Using default logging configuration.")
+
+    @patch('os.environ.get')
+    @patch('subprocess.run')
+    def test_subprocess_error(self, mock_run, mock_env_get):
+        mock_env_get.return_value = '20'
+        mock_run.side_effect = subprocess.CalledProcessError(1, 'sed')
+        
+        result = configure_log_level()
+        
+        self.assertTrue(result.startswith("Error configuring the logging"))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/unit/test_log_config.py
+++ b/test/unit/test_log_config.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import patch, MagicMock
-import os , subprocess
+import os, subprocess
 import sys
 import io
 
@@ -32,7 +32,7 @@ class TestLogConfig(unittest.TestCase):
         
         with patch('sys.stderr', new=io.StringIO()) as fake_err:
             configure_logging()
-            self.assertIn("Invalid TS_LOGLEVEL value: 70", fake_err.getvalue())
+            self.assertIn("Invalid TS_LOG_LEVEL value: 70", fake_err.getvalue())
 
     @patch('os.path.exists')
     @patch('os.environ.get')
@@ -42,7 +42,7 @@ class TestLogConfig(unittest.TestCase):
         
         with patch('sys.stdout', new=io.StringIO()) as fake_out:
             configure_logging()
-            self.assertIn("TS_LOGLEVEL not set", fake_out.getvalue())
+            self.assertIn("TS_LOG_LEVEL not set", fake_out.getvalue())
 
     @patch('os.path.exists')
     @patch('os.environ.get')

--- a/test/unit/test_log_config.py
+++ b/test/unit/test_log_config.py
@@ -1,51 +1,68 @@
 import unittest
 from unittest.mock import patch, MagicMock
-import os
-from sagemaker_pytorch_serving_container.serving import configure_log_level
+import os , subprocess
+import sys
+import io
 
-import unittest
-from unittest.mock import patch, MagicMock
-import os
-from your_module import configure_log_level  # replace 'your_module' with the actual module name
+# Add the src directory to the Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'src')))
+
+from sagemaker_pytorch_serving_container.serving import configure_logging
 
 class TestLogConfig(unittest.TestCase):
-
+    @patch('os.path.exists')
     @patch('os.environ.get')
     @patch('subprocess.run')
-    def test_valid_log_level(self, mock_run, mock_env_get):
+    def test_valid_log_level(self, mock_run, mock_env_get, mock_exists):
+        mock_exists.return_value = True
         mock_env_get.return_value = '20'
         mock_run.return_value = MagicMock(returncode=0)
         
-        result = configure_log_level()
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            configure_logging()
+            self.assertIn("Logging level set to error", fake_out.getvalue())
         
-        self.assertEqual(result, "Logging level set to error")
         mock_run.assert_called_once()
 
+    @patch('os.path.exists')
     @patch('os.environ.get')
-    def test_invalid_log_level(self, mock_env_get):
+    def test_invalid_log_level(self, mock_env_get, mock_exists):
+        mock_exists.return_value = True
         mock_env_get.return_value = '70'
         
-        result = configure_log_level()
-        
-        self.assertEqual(result, "Invalid TS_LOGLEVEL value: 70. No changes made to logging configuration.")
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            configure_logging()
+            self.assertIn("Invalid TS_LOGLEVEL value: 70", fake_err.getvalue())
 
+    @patch('os.path.exists')
     @patch('os.environ.get')
-    def test_no_log_level_set(self, mock_env_get):
+    def test_no_log_level_set(self, mock_env_get, mock_exists):
+        mock_exists.return_value = True
         mock_env_get.return_value = None
         
-        result = configure_log_level()
-        
-        self.assertEqual(result, "TS_LOGLEVEL not set. Using default logging configuration.")
+        with patch('sys.stdout', new=io.StringIO()) as fake_out:
+            configure_logging()
+            self.assertIn("TS_LOGLEVEL not set", fake_out.getvalue())
 
+    @patch('os.path.exists')
     @patch('os.environ.get')
     @patch('subprocess.run')
-    def test_subprocess_error(self, mock_run, mock_env_get):
+    def test_subprocess_error(self, mock_run, mock_env_get, mock_exists):
+        mock_exists.return_value = True
         mock_env_get.return_value = '20'
         mock_run.side_effect = subprocess.CalledProcessError(1, 'sed')
         
-        result = configure_log_level()
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            configure_logging()
+            self.assertIn("Error configuring the logging", fake_err.getvalue())
+
+    @patch('os.path.exists')
+    def test_log4j2_file_not_found(self, mock_exists):
+        mock_exists.return_value = False
         
-        self.assertTrue(result.startswith("Error configuring the logging"))
+        with patch('sys.stderr', new=io.StringIO()) as fake_err:
+            configure_logging()
+            self.assertIn("does not exist", fake_err.getvalue())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
*Issue #, if available:* : #83 

*Description of changes:* 

In some cases, excessive logging is contributing to CloudWatch logging costs. This change allows users to control the logging verbosity, potentially reducing costs while maintaining the ability to increase verbosity for debugging when needed. 

**Changes** :
- Added a new function ['configure_logging()'](https://github.com/aws/sagemaker-pytorch-inference-toolkit/commit/1d6a1a73b05ade8fa1a35e61054847931e1be287#diff-00d2c4c88dd8fc8cab28984c151062aa5d7f45eecd106d0d437d8177b411697bR25) to dynamically set log levels
- Utilize TS_LOG_LEVEL environment variable to control logging verbosity
- [Supported log levels](https://logging.apache.org/log4j/2.x/manual/customloglevels.html): `OFF`, `FATAL`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`. Re-mapped the TS_LOG_LEVEL values to corresponding integer values as follows.
```
 log_levels = {
         '0': 'off',
         '10': 'fatal',
         '20': 'error',
         '30': 'warn',
         '40': 'info',
         '50': 'debug',
         '60': 'trace'
     }
```

- Modify `log4j2.xml` file using sed command based on TS_LOG_LEVEL
- Handle potential errors during log configuration gracefully
- Call configure_logging() before starting TorchServe
- Aim to reduce excessive logging and associated CloudWatch costs
- Maintain default logging if TS_LOG_LEVEL is not set or invalid

**Tests**:
- I've added unit tests in test_log_config.py to cover various scenarios including valid log levels, invalid log levels, and error conditions. All tests are passing.
```
% python -m unittest discover -v                                               
test_invalid_log_level (test_log_config.TestLogConfig.test_invalid_log_level) ... Current script path: /Users/xxxxxxx/sagemaker-pytorch-inference-toolkit/src/sagemaker_pytorch_serving_container/serving.py
log4j2.xml path: /Users/xxxxxxx/sagemaker-pytorch-inference-toolkit/src/sagemaker_pytorch_serving_container/etc/log4j2.xml
ok
test_log4j2_file_not_found (test_log_config.TestLogConfig.test_log4j2_file_not_found) ... Current script path: /Users/xxxxxxx/sagemaker-pytorch-inference-toolkit/src/sagemaker_pytorch_serving_container/serving.py
log4j2.xml path: /Users/xxxxxxx/sagemaker-pytorch-inference-toolkit/src/sagemaker_pytorch_serving_container/etc/log4j2.xml
ok
test_no_log_level_set (test_log_config.TestLogConfig.test_no_log_level_set) ... ok
test_subprocess_error (test_log_config.TestLogConfig.test_subprocess_error) ... Current script path: /Users/xxxxxxx/sagemaker-pytorch-inference-toolkit/src/sagemaker_pytorch_serving_container/serving.py
log4j2.xml path: /Users/xxxxxxx/sagemaker-pytorch-inference-toolkit/src/sagemaker_pytorch_serving_container/etc/log4j2.xml
ok
test_valid_log_level (test_log_config.TestLogConfig.test_valid_log_level) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.002s

OK
```
**Steps to test on Pytorch container** : 

- Extend existing Pytorch container.
```
from 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.1-cpu-py310
RUN pip install git+https://github.com/lavaraja/sagemaker-pytorch-inference-toolkit.git 
```
- Build the image. 
`docker build .` 
- Tag the image. 
`docker tag <image_id>  763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.1-cpu-py310-extended`
- Use above image and pass `TS_LOG_LEVEL` as environment variable in the model class. Used [this sample example](https://github.com/aws-samples/amazon-sagemaker-local-mode/blob/247ae347437fc723b716ccf3e5e1b8dcd658d3e8/pytorch_script_mode_local_model_inference/pytorch_script_mode_local_model_inference.py#L57) for testing locally.
- modify `pytorch_script_mode_local_model_inference.py` and use custom built container as `image_uri`
```
    model = PyTorchModel(
        role=role,
        model_data=model_dir,
       # framework_version='2.1',
       # py_version='py310',
        image_uri="763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference:2.1-cpu-py310-extended",
        entry_point='inference.py',
        env={'TS_LOG_LEVEL': log_level}
    )
```
- Run `python pytorch_script_mode_local_model_inference.py` to start the container locally and run the inference.
- Observe the TS_LOG_LEVEL in effect during the torch serve start process. The same logs will be emitted to customer cloud watch logs when deployed on Sagemaker.

[test_output_with_diff_loglevels.log](https://github.com/user-attachments/files/19151526/test_output_with_diff_loglevels.log)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
